### PR TITLE
All hidden files are skipped from the test dir

### DIFF
--- a/tests/index_controller.php
+++ b/tests/index_controller.php
@@ -6,7 +6,7 @@ $failed_test_count = 0;
 
 foreach ($DirectoryIterator as $Item) 
 {
-	if ($Item->isFile() and $Item->getBasename() != '.DS_Store')
+	if ($Item->isFile() and strpos($Item->getBasename(), '.') !== 0)
 	{
 		if ($Item->getExtension() === 'md')
 		{


### PR DESCRIPTION
.DS_Store is a platform-specific file for Mac OS. It would be better to skip
all hidden files (which start with a dot).

On Windows however hidden files are marked by a file attribute, so this is
actually only valid on Unix.
