### PR TITLE
Fix for undefined variable when having a paragraph after list

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -147,7 +147,7 @@ class Parsedown
 				
 				unset($block);
 			}
-			elseif (isset($list) and $block[0] === ' ') # list item block 
+			elseif (isset($list) and isset($block) and $block[0] === ' ') # list item block 
 			{
 				$list .= "\n\n".$block;
 				

--- a/tests/index.php
+++ b/tests/index.php
@@ -1,5 +1,8 @@
 <?php 
 
+error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
+ini_set('display_errors', 'true');
+
 include '../Parsedown.php';
 
 $page = $_SERVER['QUERY_STRING']


### PR DESCRIPTION
If you turn enable error_reporting for E_NOTICE and set display_errors to
TRUE, you would see the undefined variable on several tests.

The error occurs in Parsedown.php:150. If you have a list set and then a
paragraph which satisfies the condition $block[0] > 'A'.
