### PR TITLE
Space separated asterisks should be treated as literals

### DIFF
--- a/tests/data/emphasis.html
+++ b/tests/data/emphasis.html
@@ -3,3 +3,5 @@
 <p>Here's <em>an emphasis that uses underscores</em>. </p>
 <p>Here's <strong>a strong emphasis that uses underscores</strong>.</p>
 <p>This is _ not an emphasis _.</p>
+<p>Space separated asterisks * * * is not an emphasis.</p>
+<p>Space separated underscores _ _ _ is not an emphasis.</p>

--- a/tests/data/emphasis.md
+++ b/tests/data/emphasis.md
@@ -7,3 +7,7 @@ Here's _an emphasis that uses underscores_.
 Here's __a strong emphasis that uses underscores__.
 
 This is _ not an emphasis _.
+
+Space separated asterisks * * * is not an emphasis.
+
+Space separated underscores _ _ _ is not an emphasis.


### PR DESCRIPTION
According to the Markdown specification, space separated asterisks or space
separated underscores is not an emphasis.

They should be treated as literal asterisks and underscores.

Parsedown however parses asterisks as an emphasis with a space and another
literal asterisk. Space separated underscores are parsed fine.
