### PR TITLE
Added tests for horizontal rules and fixed underscore rules

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -252,15 +252,6 @@ class Parsedown
 				continue;
 			}
 			
-			# Horizontal Line 
-			
-			if (isset($block) and preg_match('/^[ ]{0,3}([-*_])([ ]{0,2}\1){2,}$/', $block))
-			{
-				$markup .= '<hr />'."\n";
-				
-				continue;
-			}
-			
 			# ~ 
 			
 			if (isset($quick_block))
@@ -268,6 +259,18 @@ class Parsedown
 				$block = $quick_block;
 				
 				unset ($quick_block);
+			}
+			
+			# Horizontal Line
+			# Horizontal lines checks could be optimized with $quick_block
+			# But '_' > 'A' and horizontal lines could be defined by underscores
+			# See #13
+			
+			if (isset($block) and preg_match('/^[ ]{0,3}([-*_])([ ]{0,2}\1){2,}$/', $block))
+			{
+				$markup .= '<hr />'."\n";
+				
+				continue;
 			}
 			
 			# 

--- a/tests/data/horizontal_line.html
+++ b/tests/data/horizontal_line.html
@@ -1,0 +1,6 @@
+<p>Horizontal line with dashes</p>
+<hr />
+<p>Horizontal line with asterisks</p>
+<hr />
+<p>Horizontal line with underscores</p>
+<hr />

--- a/tests/data/horizontal_line.md
+++ b/tests/data/horizontal_line.md
@@ -1,0 +1,11 @@
+Horizontal line with dashes
+
+---
+
+Horizontal line with asterisks
+
+***
+
+Horizontal line with underscores
+
+___


### PR DESCRIPTION
Partial fix for #9 

I've moved the code for horizontal rules down a bit, so it is not part of the performance optimisations wtih `$quick_block`.

This could also be fixed with additional check for '_' in the quick_block check.

But this way logic and performance optimisations are separated.
