### PR TITLE
Don't run `composer --version` on install or before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ php:
 matrix:
   allow_failures:
     - php: 5.2
+
+before_install: true
+install: true


### PR DESCRIPTION
Parsedown does not require any dependecies installed via Composer to run the tests.
Travis CI is automatically running `composer --version`.
But on PHP 5.2 Composer is not working.
No need to run `composer --version` on `before_install` or `install` phase.

`true` is a *nix command which exists with 0 and therefore disables the default Travis behavior.
