### PR TITLE
Lists and indented links bug

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -182,7 +182,7 @@ class Parsedown
 
 				if (isset($element['interrupted']))
 				{
-					if ($line[0] === ' ')
+					if ($line[0] === ' ' and ! preg_match('/^[ ]{0,4}\[(.+?)\]:[ ]*([^ ]+)/', $line))
 					{
 						$element['lines'] []= '';
 


### PR DESCRIPTION
This solves a bug which stops referenced links formatting correctly when a space is inserted before a reference to a link right after a list.

This is caused because parsedown think's it's a secondary list, so it jumps to the next line.

Here is an example that shows the bug:

```
+ [Google][2]
+ [Youtube][1]  

  [1]: http://youtube.com
  [2]: http://google.com
```

You can see links formatted like this on stackoverflow.com
