### PR TITLE
Use UTF-8 encoding for htmlspecialchars.

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -568,7 +568,7 @@ class Parsedown
 				case 'code_block':
 				case 'fenced_code_block':
 
-					$text = htmlspecialchars($element['text'], ENT_NOQUOTES);
+					$text = htmlspecialchars($element['text'], ENT_NOQUOTES, 'UTF-8');
 
 					strpos($text, "\x1A\\") !== FALSE and $text = strtr($text, $this->escape_sequence_map);
 
@@ -634,7 +634,7 @@ class Parsedown
 			foreach ($matches as $matches)
 			{
 				$element_text = $matches[1];
-				$element_text = htmlspecialchars($element_text, ENT_NOQUOTES);
+				$element_text = htmlspecialchars($element_text, ENT_NOQUOTES, 'UTF-8');
 
 				# decodes escape sequences
 

--- a/tests/data/special_characters.html
+++ b/tests/data/special_characters.html
@@ -1,4 +1,5 @@
 <p>AT&amp;T has an ampersand in their name</p>
+<pre><code>Let's play some cards ♠ ♣ ♥ ♦</code></pre>
 <p>AT&amp;T is another way to write it</p>
 <p>this &amp; that</p>
 <p>4 &lt; 5 and 6 > 5</p>

--- a/tests/data/special_characters.md
+++ b/tests/data/special_characters.md
@@ -1,5 +1,7 @@
 AT&T has an ampersand in their name
 
+    Let's play some cards ♠ ♣ ♥ ♦
+
 AT&T is another way to write it
 
 this & that


### PR DESCRIPTION
See #36.

Prior to PHP 5.4.0 the default encoding for `htmlentities()` and
`htmlspecialchars` is "ISO-8859-1". For PHP 5.4+ is "UTF-8".

This ensures always the right encoding is used no matter the PHP version and
the locale settings.

I have included tests which test both the change from `htmlentities()` to
`htmlspecialshars` and the encoding.

Example output with `htmlentities()` would be:

```
Let's play some cards &clubs; &spades; &hearts; &diams;
```

Example output with `htmlentities()` and "ISO-8859-1" encoding would be:

```
Let's play some cards &acirc;?&nbsp; &acirc;?&pound; &acirc;?&yen; &acirc;?&brvbar;
```
