### PR TITLE
Add PHP 5.2 requirement to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
             "homepage": "http://erusev.com"
         }
     ],
+    "require": {
+        "php": ">=5.2.0"
+    },
     "autoload": {
         "psr-0": {"Parsedown": ""}
     }


### PR DESCRIPTION
It is nice to mention the supported PHP version in composer.json as well.
People who find the library through Packagist would easily see if the could run it.
