### PR TITLE
Support for links with target="_blank" when not matching against a specified regex

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -37,6 +37,8 @@ class Parsedown
 	# Fields
 	#
 
+	public $internal_regex = "";
+
 	private $reference_map = array();
 	private $escape_sequence_map = array();
 
@@ -646,8 +648,8 @@ class Parsedown
 				else # link
 				{
 					$element_text = $this->parse_span_elements($matches[3]);
-
-					$element = '<a href="'.$url.'">'.$element_text.'</a>';
+					$target = ($this->internal_regex == "" || preg_match ($this->internal_regex, $url)) ? ('') : ('target="_blank" ');
+					$element = '<a '.$target.'href="'.$url.'">'.$element_text.'</a>';
 				}
 
 				# ~
@@ -687,8 +689,8 @@ class Parsedown
 					else # link
 					{
 						$element_text = $this->parse_span_elements($matches[2]);
-
-						$element = '<a href="'.$url.'">'.$element_text.'</a>';
+						$target = ($this->internal_regex == "" || preg_match ($this->internal_regex, $url)) ? ('') : ('target="_blank" ');
+						$element = '<a '.$target.'href="'.$url.'">'.$element_text.'</a>';
 					}
 
 					# ~
@@ -750,7 +752,7 @@ class Parsedown
 
 						strpos($url, '&') !== FALSE and $url = preg_replace('/&(?!#?\w+;)/', '&amp;', $url);
 
-						$element = '<a href=":href">:text</a>';
+						$element = ($this->internal_regex == "" || preg_match ($this->internal_regex, $url)) ? ('<a href=":href">:text</a>') : ('<a target="_blank" href=":href">:text</a>');
 						$element = str_replace(':text', $url, $element);
 						$element = str_replace(':href', $url, $element);
 


### PR DESCRIPTION
Generally it would be nice, if the parser could recognise if a link is referring the internal site, or something external, in which case the link should open in a new window.

This patch implements the possibility to specify a regular expression in a parser instance (`public $internal_regex`) used for matching internal links. If such a regular expressions specified, than every link is checked against it. If it does not match, than a `target='_blank'` is added to the link markup.

Example:
Using the expression `#(^(http|https)://www\.yeasoft\.(de|com|net|org).*$|^/.*$|^((?!https?://).)*$)#` the following URLs are matched as internal:

```
http://www.yeasoft.com
https://www.yeasoft.net/projects:alix
/site/project:btsync-deb
relpath/xyzzy.html
```

The following URLs are recognised as external and will open in a separate window:

```
http://github.com/tuxpoldo
https://www.google.com
```
