### PR TITLE
Add ability to specify link titles on inline and reference links.

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -399,11 +399,16 @@ class Parsedown
 
 					# reference
 
-					if (preg_match('/^\[(.+?)\]:[ ]*([^ ]+)/', $deindented_line, $matches))
+					if (preg_match('/^\[(.+?)\]:\s*([^\s]+)(?:\s+["\'\(](.+)["\'\)])?/', $deindented_line, $matches))
 					{
 						$label = strtolower($matches[1]);
 
-						$this->reference_map[$label] = trim($matches[2], '<>');;
+						$this->reference_map[$label] = trim($matches[2], '<>');
+
+						if (isset($matches[3]))
+						{
+							$this->reference_map[$label.":title"] = $matches[3];
+						}
 
 						continue 2;
 					}
@@ -631,7 +636,7 @@ class Parsedown
 
 		# inline link / inline image (recursive)
 
-		if (strpos($text, '](') !== FALSE and preg_match_all('/(!?)(\[((?:[^\[\]]|(?2))*)\])\((.*?)\)/', $text, $matches, PREG_SET_ORDER))
+		if (strpos($text, '](') !== FALSE and preg_match_all('/(!?)(\[((?:[^\[\]]|(?2))*)\])\((.*?)(?:\s+["\'\(](.*?)["\'\)])?\)/', $text, $matches, PREG_SET_ORDER))
 		{
 			foreach ($matches as $matches)
 			{
@@ -647,7 +652,14 @@ class Parsedown
 				{
 					$element_text = $this->parse_span_elements($matches[3]);
 
-					$element = '<a href="'.$url.'">'.$element_text.'</a>';
+					if (isset($matches[5]))
+					{
+						$element = '<a href="'.$url.'" title="'.$matches[5].'">'.$element_text.'</a>';
+					}
+					else
+					{
+						$element = '<a href="'.$url.'">'.$element_text.'</a>';
+					}
 				}
 
 				# ~
@@ -688,7 +700,14 @@ class Parsedown
 					{
 						$element_text = $this->parse_span_elements($matches[2]);
 
-						$element = '<a href="'.$url.'">'.$element_text.'</a>';
+						if (isset($this->reference_map[$link_definition.":title"]))
+						{
+							$element = '<a href="'.$url.'" title="'.$this->reference_map[$link_definition.":title"].'">'.$element_text.'</a>';
+						}
+						else
+						{
+							$element = '<a href="'.$url.'">'.$element_text.'</a>';
+						}
 					}
 
 					# ~

--- a/tests/data/implicit_reference.html
+++ b/tests/data/implicit_reference.html
@@ -1,2 +1,3 @@
 <p>an <a href="http://example.com">implicit</a> reference link</p>
 <p>an <a href="http://example.com">implicit</a> reference link with an empty link definition</p>
+<p>an <a href="http://example.com" title="Example">explicit</a> reference link with a title</p>

--- a/tests/data/implicit_reference.md
+++ b/tests/data/implicit_reference.md
@@ -3,3 +3,7 @@ an [implicit] reference link
 [implicit]: http://example.com
 
 an [implicit][] reference link with an empty link definition
+
+an [explicit][example] reference link with a title
+
+[example]: http://example.com "Example"

--- a/tests/data/inline_link.html
+++ b/tests/data/inline_link.html
@@ -1,3 +1,4 @@
 <p><a href="http://example.com">link</a></p>
 <p><a href="http://example.com"><code>link</code></a></p>
+<p><a href="http://example.com" title="Example">link with title</a></p>
 <p><a href="http://example.com"><img alt="MD Logo" src="http://parsedown.org/md.png"></a></p>

--- a/tests/data/inline_link.md
+++ b/tests/data/inline_link.md
@@ -2,4 +2,6 @@
 
 [`link`](http://example.com)
 
+[link with title](http://example.com "Example")
+
 [![MD Logo](http://parsedown.org/md.png)](http://example.com)


### PR DESCRIPTION
The Markdown specification provides a way to specify the title attribute for inline and reference links.  This is a relatively minor change that fixes #15.

For example:

```
[Inline link](http://example.com "Example")
```

Becomes:
[Inline link](http://example.com)
