### PR TITLE
Fix HTML Bug

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -618,6 +618,12 @@ class Parsedown
 					isset($element['last']) and $markup .= '</'.$list_type.'>'."\n";
 
 					break;
+					
+				case 'markup':
+					
+					$markup .= $this->parse_span_elements($element['text'])."\n";
+
+					break;
 
 				default:
 


### PR DESCRIPTION
If you add markdown after HTML on the same line, all the remaining markdown will not be parsed.

Demo:
Add `"<span></span> *test*"` without quotes to the top of a markdown page on it's own line and then parse.

PHPUnit:

```
Time: 30 ms, Memory: 2.75Mb

OK (31 tests, 31 assertions)
```
