### PR TITLE
Adding failing test for a list with following list with links

### DIFF
--- a/tests/data/tight-link-list.html
+++ b/tests/data/tight-link-list.html
@@ -1,0 +1,7 @@
+<p>Links:</p>
+<ul>
+<li><a href="http://google.com">Google</a></li>
+<li>
+<p><a href="http://microsoft.com/">Microsoft</a></p>
+</li>
+</ul>

--- a/tests/data/tight-link-list.md
+++ b/tests/data/tight-link-list.md
@@ -1,0 +1,6 @@
+Links:
+ - [Google][2]
+ - [Microsoft][3]
+
+ [2]: http://google.com/
+ [3]: http://microsoft.com/


### PR DESCRIPTION
Didn't take a close look at what's happening yet.

This is the output created by PHPUnit:

```
PHPUnit 3.7.28 by Sebastian Bergmann.

Configuration read from C:\Users\AnhNhan\Documents\dev\parsedown\phpunit.xml.dist

............................[41;37mF[0m...

Time: 156 ms, Memory: 2.00Mb

There was 1 failure:

1) Test::test_ with data set #28 ('Links:
 - [Google][2]
 - [Microsoft][3]

 [2]: http://google.com/
 [3]: http://microsoft.com/', '<p>Links:</p>
<ul>
<li><a href="http://google.com">Google</a></li>
<li>
<p><a href="http://microsoft.com/">Microsoft</a></p>
</li>
</ul>')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<p>Links:</p>
 <ul>
-<li><a href="http://google.com">Google</a></li>
+<li>[Google][2]</li>
 <li>
 <p><a href="http://microsoft.com/">Microsoft</a></p>
 </li>
 </ul>'

C:\Users\AnhNhan\Documents\dev\parsedown\tests\Test.php:16

[37;41m[2KFAILURES!
[0m[37;41m[2KTests: 32, Assertions: 32, Failures: 1.
[0m[2K

```
