### PR TITLE
Use imperative tense in comments

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -41,7 +41,7 @@ class Parsedown
     private $breaks_enabled = false;
 
     #
-    # Enables GFM line breaks.
+    # Enable GFM line breaks.
 
     function set_breaks_enabled($breaks_enabled)
     {
@@ -61,27 +61,27 @@ class Parsedown
     #
 
     #
-    # Converts Markdown to HTML.
+    # Convert Markdown to HTML.
 
     function parse($text)
     {
-        # standardizes line breaks
+        # standardize line breaks
         $text = str_replace("\r\n", "\n", $text);
         $text = str_replace("\r", "\n", $text);
 
-        # replaces tabs with spaces
+        # replace tabs with spaces
         $text = str_replace("\t", '    ', $text);
 
-        # removes surrounding line breaks
+        # remove surrounding line breaks
         $text = trim($text, "\n");
 
-        # splits text into lines
+        # split text into lines
         $lines = explode("\n", $text);
 
-        # converts lines into html
+        # convert lines into html
         $text = $this->parse_block_elements($lines);
 
-        # removes trailing line breaks
+        # remove trailing line breaks
         $text = chop($text, "\n");
 
         return $text;


### PR DESCRIPTION
There are number of style guides, recommendations and suggestions about
formatting and wording of the comments in your code.

One of the "rules" which seems quite common is the usage of present
imperative tense instead of third-person.

Here are some of the resources I've just found:
- http://luisespinal.wordpress.com/2012/01/02/rules-for-commenting-code-revisited-v2/
- http://stackoverflow.com/questions/8910214/comment-style-imperative-or-third-person
- http://www.hongkiat.com/blog/source-code-comment-styling-tips/
- http://luisespinal.wordpress.com/2011/03/11/simple-rules-on-commenting-code/
- http://www.devtopics.com/13-tips-to-comment-your-code/

Also there is a similar recommendation for commits messages (which serve similar purpose):
- http://programmers.stackexchange.com/questions/157590/why-is-it-preferred-to-write-a-commit-message-in-present-tense-imperative-mood
- http://programmers.stackexchange.com/questions/56031/version-control-comments-past-or-present-tense
- http://stackoverflow.com/questions/3580013/should-i-use-past-or-present-tense-in-git-commit-messages

My personal arguments are:
- It is shorter.
- It sounds like programming without the programming language. Imagine writing the comments first. You would definitely write them in imperative form.
