### PR TITLE
Add unicode support for strong/em regex.

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -931,7 +931,7 @@ class Parsedown
 
                     if (strpos($text, '>') !== false)
                     {
-                        if ($text[1] === 'h' and preg_match('/^<(https?:[\/]{2}[^\s]+?)>/ui', $text, $matches))
+                        if ($text[1] === 'h' and preg_match('/^<(https?:[\/]{2}[^\s]+?)>/i', $text, $matches))
                         {
                             $element_url = $matches[1];
                             $element_url = str_replace('&', '&amp;', $element_url);


### PR DESCRIPTION
Hi, do you think maybe it would be reasonable to add support for unicode characters in regexes like `$em_regex`, `$strong_regex` etc.?

For example, let's take a filename: `black_cat_picture.jpg`.
With github flavored Markdown we can see underscores in the middle of the word: "black_cat_picture.jpg".

Now, let's try the same thing with Japanese filename `黒_ネコ_の絵.jpg`.
In this case Markdown will return: "黒_ネコ_の絵.jpg" (ネコ is being italicized).
