### PR TITLE
added pre_process_block_element() method hook

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -86,6 +86,30 @@ class Parsedown
         return $text;
     }
 
+
+    #
+    # This method will be called before an element will be transformed to html.
+    #
+    # The markdown element is represented as an array which is given by reference so you can manipulate
+    # it directly. You may override this method to do arbitrary adjustments to the elements properties and content.
+    #
+    # @param array $block the markdown element to process. This array always has a 'type' key which refers to the type
+    # of element given. There may be further keys in the array dependent on the element type such as 'text' or 'lines'.
+    # Available types are among others:
+    # - 'markup'
+    # - 'quote'
+    # - 'code'
+    # - 'fenced'
+    # - 'rule'
+    # - 'heading'
+    # - 'li'
+    # - 'paragraph'
+    #
+    protected function pre_process_block_element(&$block)
+    {
+    }
+
+
     #
     # Private
 
@@ -576,6 +600,10 @@ class Parsedown
 
         foreach ($blocks as $block)
         {
+            # allow extending classes to pre-process the element
+            # before it is converted to html
+            $this->pre_process_block_element($block);
+
             switch ($block['type'])
             {
                 case 'paragraph':


### PR DESCRIPTION
This method allows to pre-process markdown blocks before they are
rendered to html.

This allows for example to process code blocks for syntax highlighting
but is very flexible as it allows to work with any block type in
arbitrary ways.

I tried to adopt to your code style, hope everything looks as it should. Btw, what is the reason you are not using phpdoc standard for class and method description?
