### PR TITLE
added parseLine() method for parsing oneliners

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -92,7 +92,7 @@ class Parsedown
     function parseLine($line)
     {
         # remove line breaks and replace tabs with spaces
-        $line = str_replace(["\r\n", "\n", "\r", "\t"], ' ', $line);
+        $line = str_replace(array("\r\n", "\n", "\r", "\t"), ' ', $line);
 
         # remove surrounding line breaks and space
         $line = trim($line);


### PR DESCRIPTION
a "oneliner" is markown without linebreaks that is considered to only
contain non-block elements.
It will be parsed and returned without surrounding `<p>` tags.

A usecase is described in https://github.com/erusev/parsedown/issues/43#issuecomment-33586666

fixes #43
