### PR TITLE
Add a CLI mode to allow parsing markdown at the command line

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -13,6 +13,14 @@
 #
 #
 
+if (Parsedown::is_cli() && is_readable($argv[1])) {
+	$str  = file_get_contents($argv[1]);
+
+	print Parsedown::instance()->parse($str);
+
+	exit();
+}
+
 class Parsedown
 {
     # Multiton
@@ -47,6 +55,16 @@ class Parsedown
     }
 
     private $breaks_enabled = false;
+
+	# Detect if we're running in CLI mode
+
+	public static function is_cli() {
+		if (php_sapi_name() == 'cli') {
+			return true;
+		}
+
+		return false;
+	}
 
     #
     # Synopsis

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -48,16 +48,6 @@ class Parsedown
 
     private $breaks_enabled = false;
 
-	# Detect if we're running in CLI mode
-
-	public static function is_cli() {
-		if (php_sapi_name() == 'cli') {
-			return true;
-		}
-
-		return false;
-	}
-
     #
     # Synopsis
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -13,20 +13,6 @@
 #
 #
 
-if (Parsedown::is_cli()) {
-	$file_mode = is_readable($argv[1]);
-
-	if ($file_mode) {
-		$str = file_get_contents($argv[1]);
-	} else {
-		$str = file_get_contents("php://stdin");
-	}
-
-	print Parsedown::instance()->parse($str);
-
-	exit();
-}
-
 class Parsedown
 {
     # Multiton

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -13,8 +13,14 @@
 #
 #
 
-if (Parsedown::is_cli() && is_readable($argv[1])) {
-	$str  = file_get_contents($argv[1]);
+if (Parsedown::is_cli()) {
+	$file_mode = is_readable($argv[1]);
+
+	if ($file_mode) {
+		$str = file_get_contents($argv[1]);
+	} else {
+		$str = file_get_contents("php://stdin");
+	}
 
 	print Parsedown::instance()->parse($str);
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ $result = Parsedown::instance()->parse($text);
 
 echo $result; # prints: <p>Hello <em>Parsedown</em>!</p>
 ```
+
+### CLI Example
+
+```
+php Parsedown.php document.md > document.html
+```

--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ echo $result; # prints: <p>Hello <em>Parsedown</em>!</p>
 ### CLI Example
 
 ```
-php Parsedown.php document.md > document.html
+cd bin
+./parsedown document.md > document.html
 ```

--- a/bin/parsedown
+++ b/bin/parsedown
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?PHP
+
+$dir = dirname(__FILE__);
+require("$dir/../Parsedown.php");
+
+//////////////////////////////////////////////
+
+$file_mode = is_readable($argv[1]);
+
+// From a file
+if ($file_mode) {
+	$str = file_get_contents($argv[1]);
+// From STDIN
+} else {
+	$str = file_get_contents("php://stdin");
+}
+
+print Parsedown::instance()->parse($str);

--- a/bin/parsedown
+++ b/bin/parsedown
@@ -1,15 +1,13 @@
 #!/usr/bin/env php
-<?PHP
+<?php
 
 $dir = dirname(__FILE__);
 require("$dir/../Parsedown.php");
 
 //////////////////////////////////////////////
 
-$file_mode = is_readable($argv[1]);
-
 // From a file
-if ($file_mode) {
+if (isset($argv[1]) && is_readable($argv[1])) {
 	$str = file_get_contents($argv[1]);
 // From STDIN
 } else {

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,5 @@
     "autoload": {
         "psr-0": {"Parsedown": ""}
     },
-	"bin": ["bin/parsedown"]
+    "bin": ["bin/parsedown"]
 }

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,6 @@
     ],
     "autoload": {
         "psr-0": {"Parsedown": ""}
-    }
+    },
+	"bin": ["bin/parsedown"]
 }


### PR DESCRIPTION
I was writing a lot of tests, and then copy/pasting the HTML from my browser to the appropriate HTML file, which was very time consuming. Then it occurred to me that we could use Parsedown.php **as** the CLI tool. With this code you can now do:

```
php Parsedown.php document.md > document.html
```
