### PR TITLE
Add contribution guidelines file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-.DS_Store
-.idea
-nbproject

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ $result = Parsedown::instance()->parse($text);
 
 echo $result; # prints: <p>Hello <em>Parsedown</em>!</p>
 ```
+
+### Contributing
+
+Please follow the [contribution guidelines](contributing.md).

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,22 @@
+### Issues
+
+If you have a question or a feature request feel free to open a new issue here - https://github.com/erusev/parsedown/issues/new.
+
+Checkout existing issues before opening a new one.
+
+### Pull Requests
+
+ * Always open an issue (or comment on existing ones) before working on a pull request.  
+   You could later [reference the issue](https://github.com/blog/1506-closing-issues-via-pull-requests) in the pull request.  
+   Do not write significat amount of code before discussing it first.  
+ * Create a "feature" branch from `master` for your pull request.
+ * Create your pull request from your "feature" branch to the `master` branch.
+ * Run existing unit tests (with `phpunit`) and write your own. [Travis CI](http://docs.travis-ci.com/user/getting-started/) would [take care of PRs automatically](http://blog.travis-ci.com/announcing-pull-request-support/), but you could run the tests locally before that.
+
+### Ignored Files
+
+Do not commit system files, but don't clutter [.gitignore](.gitignore). Use a [useful global .gitignore](https://help.github.com/articles/ignoring-files#global-gitignore).
+
+### Coding style
+
+Please try to follow the existing coding style.


### PR DESCRIPTION
Add initial version of `contributing.md`.

GitHub would show a link to this file on the new issue page and when opening a
PR. 
https://help.github.com/articles/how-do-i-set-up-guidelines-for-contributors

Remove .gitignore as there is nothing to ignore from this project. GitHub
recommendation is to have just project-specific paths ignored in the
.gitignore file of the repo. Platform-specific files and editor-specific files
should go in a global gitignore file. 
https://help.github.com/articles/ignoring-files#global-gitignore

---

I guess you could always write your own guidelines or edit these ones, but it's a start.

I could split it up in separate PRs or remove some parts of this one if you'd like.
