### PR TITLE
simplify testing and improved output

### DIFF
--- a/tests/Test.php
+++ b/tests/Test.php
@@ -9,8 +9,14 @@ class Test extends PHPUnit_Framework_TestCase
 	/**
 	 * @dataProvider provider
 	 */
-	function test_($markdown, $expected_markup)
+	function test_($filename)
 	{
+		$path = $this->get_data_path();
+		$markdown = file_get_contents($path . $filename . '.md');
+		$expected_markup = file_get_contents($path . $filename . '.html');
+		$expected_markup = str_replace("\r\n", "\n", $expected_markup);
+		$expected_markup = str_replace("\r", "\n", $expected_markup);
+
 		$actual_markup = Parsedown::instance()->parse($markdown);
 
 		$this->assertEquals($expected_markup, $actual_markup);
@@ -20,9 +26,8 @@ class Test extends PHPUnit_Framework_TestCase
 	{
 		$provider = array();
 
-		$path = dirname(__FILE__).'/';
-
-		$DirectoryIterator = new DirectoryIterator($path . '/' . self::provider_dir);
+		$path = $this->get_data_path();
+		$DirectoryIterator = new DirectoryIterator($path);
 
 		foreach ($DirectoryIterator as $Item)
 		{
@@ -36,20 +41,17 @@ class Test extends PHPUnit_Framework_TestCase
 					continue;
 
 				$basename = $Item->getBasename('.md');
-
-				$markdown = file_get_contents($path . '/' . self::provider_dir . $basename . '.md');
-
-				if (!$markdown)
-					continue;
-
-				$expected_markup = file_get_contents($path . '/' . self::provider_dir . $basename . '.html');
-				$expected_markup = str_replace("\r\n", "\n", $expected_markup);
-				$expected_markup = str_replace("\r", "\n", $expected_markup);
-
-				$provider [] = array($markdown, $expected_markup);
+				if (file_exists($path.$basename.'.html')) {
+					$provider [] = array($basename);
+				}
 			}
 		}
 
 		return $provider;
+	}
+
+	function get_data_path()
+	{
+		return dirname(__FILE__).'/'.self::provider_dir;
 	}
 }


### PR DESCRIPTION
Improve testing output by moving the `file_get_contents()` call to the test method.
This way PHPUnit will not clutter output with the expected html and markdown but only show the filename.
This makes it much easier to read the testing ouput of failed tests:

before:

```
There were 2 failures:

1) Test::test_ with data set #37 ('- li

  line
  line
- li
- [[test]] [a link](http://www.google.com)
  line2

- li
', '<ul>
<li>
<p>li</p>
<p>line
line</p>
</li>
<li>
<p>[[test]] <a href="http://www.google.com">a link</a></p>
<p>line2</p>
</li>
<li>
<p>li</p>
</li>
</ul>')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 </li>
+<li>li</li>
 <li>
-<p>[[test]] <a href="http://www.google.com">a link</a></p>
-<p>line2</p>
+<p>[[test]] <a href="http://www.google.com">a link</a>
+line2</p>
 </li>
-<li>
-<p>li</p>
-</li>
+<li>li</li>
 </ul>'

/home/cebe/dev/github/yiisoft/yii2/extensions/apidoc/vendor/erusev/parsedown/tests/Test.php:16
...
```

after:

```
1) Test::test_ with data set #37 ('multiline_lazy_list')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 </li>
+<li>li</li>
 <li>
-<p>[[test]] <a href="http://www.google.com">a link</a></p>
-<p>line2</p>
+<p>[[test]] <a href="http://www.google.com">a link</a>
+line2</p>
 </li>
-<li>
-<p>li</p>
-</li>
+<li>li</li>
 </ul>'
```
