### PR TITLE
Improve code span parsing

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -974,9 +974,9 @@ class Parsedown
 
                 case '`':
 
-                    if (preg_match('/^(`+)(.+?)\1(?!`)/', $text, $matches))
+                    if (preg_match('/^(`+)([ ]?)(.+?)\2\1/', $text, $matches))
                     {
-                        $element_text = $matches[2];
+                        $element_text = $matches[3];
                         $element_text = htmlspecialchars($element_text, ENT_NOQUOTES, 'UTF-8');
 
                         $markup .= '<code>'.$element_text.'</code>';

--- a/tests/data/code_span_adjacent.html
+++ b/tests/data/code_span_adjacent.html
@@ -1,0 +1,1 @@
+<p><code>code span</code><code>another code span</code></p>

--- a/tests/data/code_span_adjacent.md
+++ b/tests/data/code_span_adjacent.md
@@ -1,0 +1,1 @@
+`code span``another code span`

--- a/tests/data/code_span_spaces.html
+++ b/tests/data/code_span_spaces.html
@@ -1,0 +1,4 @@
+<p>A single backtick in a code span: <code>`</code></p>
+<p>A backtick-delimited string in a code span: <code>`foo`</code></p>
+<p>Multiple spaces: <code> like that </code></p>
+<p>Unequal number of spaces: <code> like that  </code></p>

--- a/tests/data/code_span_spaces.md
+++ b/tests/data/code_span_spaces.md
@@ -1,0 +1,7 @@
+A single backtick in a code span: `` ` ``
+
+A backtick-delimited string in a code span: `` `foo` ``
+
+Multiple spaces: ``  like that  ``
+
+Unequal number of spaces: ``  like that   ``


### PR DESCRIPTION
- Fix #89. Support single spaces as code span delimiters inside backticks.
- Fix #92. Support adjacent code spans.

---

I am resolving both of the issues in a single PR, because the
solutions are strictly tied to a single regex.

I could split them up if it would make sense and the one which would be merged second
could be rebased on to the one merged first.
