### PR TITLE
check the validity of heading

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -277,18 +277,31 @@ class Parsedown
 
                     if (isset($line[1]))
                     {
-                        $blocks []= $block;
-
                         $level = 1;
 
-                        while (isset($line[$level]) and $line[$level] === '#')
+                        while (isset($line[$level]) and $level < 7 and $line[$level] === '#')
                         {
                             $level++;
                         }
 
+                        # check heading level
+                        if ($level == 7)
+                        {
+                            break;
+                        }
+
+                        $heading = trim($line, '# ');
+                        # check heading text
+                        if ( ! isset($heading[0]))
+                        {
+                            break;
+                        }
+
+                        $blocks []= $block;
+
                         $block = array(
                             'type' => 'heading',
-                            'text' => trim($line, '# '),
+                            'text' => $heading,
                             'level' => $level,
                         );
 

--- a/tests/data/atx_heading2.html
+++ b/tests/data/atx_heading2.html
@@ -1,0 +1,8 @@
+<p>check the validity of the headings</p>
+<p>#
+##
+###
+####
+#####
+######</p>
+<p>####### h7 is not valid #######</p>

--- a/tests/data/atx_heading2.md
+++ b/tests/data/atx_heading2.md
@@ -1,0 +1,10 @@
+check the validity of the headings
+
+#
+##
+###
+####
+#####
+######
+
+####### h7 is not valid #######


### PR DESCRIPTION
parsedown does not check the validity of the title heading
## examples

```
#######
```
###### 

| GFM | parsedown |
| --- | --- |
| OK | `<h6></h6>` |

```
############# 1 ##############
```
###### ######## 1

| GFM | parsedown | markdown extra |
| --- | --- | --- |
| OK | `<h27></h27>` | `<h6>######## 1</h6>` |
