### PR TITLE
Run the testsuite on PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.6
   - 5.5
   - 5.4
   - 5.3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Better [Markdown](http://en.wikipedia.org/wiki/Markdown) parser for PHP.
 * [fast](http://parsedown.org/speed)
 * [consistent](http://parsedown.org/consistency)
 * [GitHub Flavored](https://help.github.com/articles/github-flavored-markdown)
-* [tested](https://travis-ci.org/erusev/parsedown) in PHP 5.2, 5.3, 5.4, 5.5 and [hhvm](http://www.hhvm.com/)
+* [tested](https://travis-ci.org/erusev/parsedown) in PHP 5.2, 5.3, 5.4, 5.5, 5.6 and [hhvm](http://www.hhvm.com/)
 * friendly to international input
 
 ### Installation


### PR DESCRIPTION
Travis CI recently added PHP 5.6 to their PHP environments.
