### PR TITLE
accept break and spaces in a reference label

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -818,7 +818,7 @@ class Parsedown
                 case '![':
                 case '[':
 
-                    if (strpos($text, ']') and preg_match('/\[((?:[^][]|(?R))*)\]/', $text, $matches))
+                    if (strpos($text, ']') and preg_match('/\[((?:[^][]|(?R))*)\]/s', $text, $matches))
                     {
                         $element = array(
                             '!' => $text[0] === '!',
@@ -848,6 +848,7 @@ class Parsedown
                         elseif ($this->reference_map)
                         {
                             $reference = $element['a'];
+                            $reference = preg_replace('/\s+/s', ' ', $reference);
 
                             if (preg_match('/^\s*\[(.*?)\]/', $remaining_text, $matches))
                             {


### PR DESCRIPTION
Markdown.pl 1.0.2b8 support line breaks in reference label

```
This one has a [line
break].

This one has a [line
break] with a line-ending space.

    [line break]: /foo
```

This one has a [line
break](/foo).

This one has a [line
break](/foo) with a line-ending space.

---

(GFM support it correctly)

and this fix also accept spaces in label like as many other Markdown dialects such as Marked, pandoc etc.
