### PR TITLE
use $closestMarkerIndex

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1117,14 +1117,14 @@ class Parsedown
 
                     if ($text[1] === $closestMarker and preg_match(self::$strongRegex[$closestMarker], $text, $matches))
                     {
-                        $markers[] = $closestMarker;
+                        $markers[$closestMarkerIndex] = $closestMarker;
                         $matches[1] = $this->parseLine($matches[1], $markers);
 
                         $markup .= '<strong>'.$matches[1].'</strong>';
                     }
                     elseif (preg_match(self::$emRegex[$closestMarker], $text, $matches))
                     {
-                        $markers[] = $closestMarker;
+                        $markers[$closestMarkerIndex] = $closestMarker;
                         $matches[1] = $this->parseLine($matches[1], $markers);
 
                         $markup .= '<em>'.$matches[1].'</em>';


### PR DESCRIPTION
this commit fix the regression bug introduced by 59907ff7578370dd554fe30e2de508dc696c29a9 commit

example

```
**strong** **strong** **strong** **strong** **strong** **strong** **strong** **strong** .....
**strong** **strong** **strong** **strong** **strong** **strong** ....
```

in this case `$closestMarker;` ("`*`" mark) is appended again and again and it make slowdown
