### PR TITLE
Add set_breaks_enabled() as an alias for BC

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -38,6 +38,16 @@ class Parsedown
         return $this;
     }
 
+    /**
+     * For backwards compatibility before PSR-2 naming.
+     *
+     * @deprecated Use setBreaksEnabled instead.
+     */
+    function set_breaks_enabled($breaks_enabled)
+    {
+        return $this->setBreaksEnabled($breaks_enabled);
+    }
+
     private $breaksEnabled = false;
 
     #


### PR DESCRIPTION
Backwards-compatibility is kept with versions before PSR-2 naming.

See http://git.io/SsTarw

---

I've added PHPDoc in a `/** */` comment so IDEs and other software could read the annotations.
If you want I could write it using `#` comments
