### PR TITLE
http links should be opened in a new window by default

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1163,7 +1163,7 @@ class Parsedown
                             $elementUrl = str_replace('&', '&amp;', $elementUrl);
                             $elementUrl = str_replace('<', '&lt;', $elementUrl);
 
-                            $markup .= '<a href="'.$elementUrl.'">'.$elementUrl.'</a>';
+                            $markup .= '<a href="'.$elementUrl.'" target="_blank">'.$elementUrl.'</a>';
 
                             $offset = strlen($matches[0]);
                         }
@@ -1240,7 +1240,7 @@ class Parsedown
                         $elementUrl = str_replace('&', '&amp;', $elementUrl);
                         $elementUrl = str_replace('<', '&lt;', $elementUrl);
 
-                        $markup .= '<a href="'.$elementUrl.'">'.$elementUrl.'</a>';
+                        $markup .= '<a href="'.$elementUrl.'" target="_blank">'.$elementUrl.'</a>';
 
                         $offset = strlen($matches[0]);
                     }


### PR DESCRIPTION
<a> tags generated by parsedown should open a new window by default so that the current content won't be navigated away by click.
