### PR TITLE
getHTMLForLink() to allow sub classes to override

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1084,14 +1084,7 @@ class Parsedown
                         {
                             $element['text'] = $this->parseLine($element['text'], $markers);
 
-                            $markup .= '<a href="'.$element['link'].'"';
-
-                            if (isset($element['title']))
-                            {
-                                $markup .= ' title="'.$element['title'].'"';
-                            }
-
-                            $markup .= '>'.$element['text'].'</a>';
+                            $markup .= $this->getHTMLForLink($element['link'], isset($element['title']) ? $element['title'] : null, $element['text']);
                         }
 
                         unset($element);
@@ -1163,13 +1156,13 @@ class Parsedown
                             $elementUrl = str_replace('&', '&amp;', $elementUrl);
                             $elementUrl = str_replace('<', '&lt;', $elementUrl);
 
-                            $markup .= '<a href="'.$elementUrl.'">'.$elementUrl.'</a>';
+                            $markup .= $this->getHTMLForLink($elementUrl, null, $elementUrl);
 
                             $offset = strlen($matches[0]);
                         }
                         elseif (strpos($text, '@') > 1 and preg_match('/<(\S+?@\S+?)>/', $text, $matches))
                         {
-                            $markup .= '<a href="mailto:'.$matches[1].'">'.$matches[1].'</a>';
+                            $markup .= $this->getHTMLForLink("mailto:".$matches[1], null, $matches[1]);
 
                             $offset = strlen($matches[0]);
                         }
@@ -1240,7 +1233,7 @@ class Parsedown
                         $elementUrl = str_replace('&', '&amp;', $elementUrl);
                         $elementUrl = str_replace('<', '&lt;', $elementUrl);
 
-                        $markup .= '<a href="'.$elementUrl.'">'.$elementUrl.'</a>';
+                        $markup .= $this->getHTMLForLink($elementUrl, null, $elementUrl);
 
                         $offset = strlen($matches[0]);
                     }
@@ -1337,4 +1330,11 @@ class Parsedown
                           'span',
                           'time',
     );
+	
+	
+	
+	protected function getHTMLForLink($href, $title, $contents) {
+		return '<a href="'.$href.'"'.($title?' title="'.$title.'"':'').'>'.$contents.'</a>';
+	}
+	
 }


### PR DESCRIPTION
You probably won't like this but we'll try ... :-)

I have a use case where I have a folder of MD files. I want to convert them to a folder of HTML files. So far so good - a simple PHP script with your library has done the job.

But there are times where one markdown file wants to link to another markdown file. When we convert to HTML, we don't want to link to the MD, we want to link to the associated HTML.

So basically on converting MD to HTML, I want to rewrite URLs slightly.

Hopefully I've come up with a nice solution .... I didn't want to add URL rewriting into Parsedown - instead I thought let's provide some hooks that other programmers can call to do what they want in terms of extending the functionality without adding to the complexity of the original class.

Add a function getHTMLForLink() which takes params and generates HTML. Parsedown class then calls that to generate any HTML. The changes to your class are minimal, the API is the same, all tests pass.

I can then extend the Parsedown class, override the getHTMLForLink() method and do URL rewriting in there. 
