### PR TITLE
Run composer install in Travis CI before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ php:
   - 5.3
   - 5.2
   - hhvm
+
+before_install: composer self-update
+install: composer install


### PR DESCRIPTION
Tests are using the Composer autoloader since:
https://github.com/erusev/parsedown/commit/cd1c030362351d6006f0c2cbe52b7fbd65ca9ef8

Because of that Composer should have actually dumped the autoloader in the
`vendor/` folder, before the tests are ran.
