### PR TITLE
identifyEscapeSequence() needs Array check

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1041,7 +1041,7 @@ class Parsedown
 
     protected function identifyEscapeSequence($excerpt)
     {
-        if (in_array($excerpt[1], $this->specialCharacters))
+        if (isset($excerpt[1]) && in_array($excerpt[1], $this->specialCharacters))
         {
             return array(
                 'markup' => $excerpt[1],


### PR DESCRIPTION
```
PHP Notice:  Uninitialized string offset: 1 in /home/scarwu/Workspace/Development/Pointless/vendor/erusev/parsedown/Parsedown.php on line 1044

Notice: Uninitialized string offset: 1 in /home/scarwu/Workspace/Development/Pointless/vendor/erusev/parsedown/Parsedown.php on line 1044
```

Hi, I run Parsedown with this Notice. So, I added a isset() function to check array.

```
protected function identifyEscapeSequence($excerpt)
{
    if (isset($excerpt[1]) && in_array($excerpt[1], $this->specialCharacters))
    {
```
