### PR TITLE
Add `noMarkup` option to escape user HTML

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -59,9 +59,27 @@ class Parsedown
 
     private $breaksEnabled;
 
+    /**
+     * @var boolean If true HTML is escaped
+     */
+    private $noMarkup = false;
+
     function setBreaksEnabled($breaksEnabled)
     {
         $this->breaksEnabled = $breaksEnabled;
+
+        return $this;
+    }
+
+    /**
+     * Set the `noMarkup` option
+     *
+     * @param  boolean $noMarkup If true HTML is escaped
+     * @return $this
+     */
+    function setNoMarkup($noMarkup)
+    {
+        $this->noMarkup = (bool) $noMarkup;
 
         return $this;
     }
@@ -619,6 +637,11 @@ class Parsedown
 
     protected function identifyMarkup($Line)
     {
+        if ($this->noMarkup)
+        {
+            return null;
+        }
+
         if (preg_match('/^<(\w[\w\d]*)(?:[ ][^>]*)?(\/?)[ ]*>/', $Line['text'], $matches))
         {
             if (in_array($matches[1], $this->textLevelElements))
@@ -1144,6 +1167,11 @@ class Parsedown
 
     protected function identifyTag($Excerpt)
     {
+        if ($this->noMarkup)
+        {
+            return null;
+        }
+
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<\/?\w.*?>/', $Excerpt['text'], $matches))
         {
             return array(

--- a/test/Test.php
+++ b/test/Test.php
@@ -62,4 +62,46 @@ class Test extends PHPUnit_Framework_TestCase
 
         return $data;
     }
+
+    public function test_no_markup()
+    {
+        $markdownWithHtml = <<<MARKDOWN_WITH_MARKUP
+<div>_content_</div>
+
+sparse:
+
+<div>
+<div class="inner">
+_content_
+</div>
+</div>
+
+paragraph
+
+<style type="text/css">
+    p {
+        color: red;
+    }
+</style>
+MARKDOWN_WITH_MARKUP;
+
+        $expectedHtml = <<<EXPECTED_HTML
+<p>&lt;div><em>content</em>&lt;/div></p>
+<p>sparse:</p>
+<p>&lt;div>
+&lt;div class="inner">
+<em>content</em>
+&lt;/div>
+&lt;/div></p>
+<p>paragraph</p>
+<p>&lt;style type="text/css"></p>
+<pre><code>p {
+    color: red;
+}</code></pre>
+<p>&lt;/style></p>
+EXPECTED_HTML;
+        $parsedownWithNoMarkup = new Parsedown();
+        $parsedownWithNoMarkup->setNoMarkup(true);
+        $this->assertEquals($expectedHtml, $parsedownWithNoMarkup->text($markdownWithHtml));
+    }
 }


### PR DESCRIPTION
Resolves #106. Addresses #161.

This change introduces a new option - `noMarkup`. You could set it in the
`setNoMarkup()` method similar to the `setBreaksEnabled()` one.

Example usage:

``` php
<?php

$parsedown = new Parsedown();
$parsedown->setNoMarkup(true);
$parsedown->text('<div><strong>*Some text*</strong></div>');

// Outputs:
// <p>&lt;div>&lt;strong><em>Some text</em>&lts;/strong>&lt;/div></p>
```
