### PR TITLE
Added missing require block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
             "homepage": "http://erusev.com"
         }
     ],
+    "require": {
+        "php": ">=5.3.3",
+        "ext-mbstring": "*"
+    },
     "autoload": {
         "psr-0": {"Parsedown": ""}
     }


### PR DESCRIPTION
NB, composer doesn't even run on php 5.2 so there'd be no point in allowing it in the version constraint.

Also, I think it's irresponsible to support php 5.2 given it's oel and there are known vulnerabilities

---
http://blog.ircmaxell.com/2014/12/on-php-version-requirements.html
http://blog.ircmaxell.com/2014/12/php-install-statistics.html