### PR TITLE
Fix for Parsedown stripping classes on images supported by ParsedownExtra

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1298,6 +1298,8 @@ class Parsedown
 
         $Inline = $this->inlineLink($excerpt);
 
+        $backup = $Inline;
+
         if ($Inline === null)
         {
             return;
@@ -1305,14 +1307,12 @@ class Parsedown
 
         $Inline['extent'] ++;
 
-        $Inline['element'] = array(
-            'name' => 'img',
-            'attributes' => array(
-                'src' => $Inline['element']['attributes']['href'],
-                'alt' => $Inline['element']['text'],
-                'title' => $Inline['element']['attributes']['title'],
-            ),
-        );
+        $Inline['element']['name'] = 'img';
+        $Inline['element']['attributes']['src'] = $Inline['element']['attributes']['href'];
+        unset($Inline['element']['attributes']['href']);
+
+        $Inline['element']['attributes']['alt'] = $Inline['element']['text'];
+        unset($Inline['element']['text']);
 
         return $Inline;
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1298,8 +1298,6 @@ class Parsedown
 
         $Inline = $this->inlineLink($excerpt);
 
-        $backup = $Inline;
-
         if ($Inline === null)
         {
             return;


### PR DESCRIPTION
More extensive detail of what's going on here:

https://github.com/erusev/parsedown-extra/issues/32

However, in short: With the refactoring in Parsedown 1.2.0, `inlineImage()` and `inlineLInk()` were split out into two separate methods.  This for the most part works great, but with ParsedownExtra's class support for images, it becomes a problem.  The class attributes are stripped out in Parsedown's `inlineImage()` method because it creates a non-markdown-extra formatted Inline element from scratch.

My solution, although there may be a better one, is to manipulate the Inline element so the class attribute is not lost (if it exists).