### PR TITLE
breaksEnabled fix

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1426,7 +1426,7 @@ class Parsedown
     # ~
 
     protected $unmarkedInlineTypes = array(
-        "  \n" => 'Break',
+        "\n" => 'Break',
         '://' => 'Url',
     );
 


### PR DESCRIPTION
Hello, I had a problem with my application after recent release where all linebreaks, with option breaksEnabled set to true, were ignored.
I am not familiar with all the changes you have done to the parser but the issue seems to lie on this one line.

I did test it localy and all seems to work as intended, but if no, feel free to close this PR :smile:

