### PR TITLE
Fixes #283

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1197,7 +1197,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:[ ]+("[^"]+"|\'[^\']+\'))?[)]/', $remainder, $matches))
+        if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:[ ]+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
         {
             $Element['attributes']['href'] = $matches[1];
 

--- a/test/data/image_title.html
+++ b/test/data/image_title.html
@@ -1,1 +1,2 @@
 <p><img src="/md.png" alt="alt" title="title" /></p>
+<p><img src="/md.png" alt="blank title" title="" /></p>

--- a/test/data/image_title.md
+++ b/test/data/image_title.md
@@ -1,1 +1,3 @@
 ![alt](/md.png "title")
+
+![blank title](/md.png "")

--- a/test/data/inline_link_title.html
+++ b/test/data/inline_link_title.html
@@ -1,4 +1,6 @@
 <p><a href="http://example.com" title="Title">single quotes</a></p>
 <p><a href="http://example.com" title="Title">double quotes</a></p>
+<p><a href="http://example.com" title="">single quotes blank</a></p>
+<p><a href="http://example.com" title="">double quotes blank</a></p>
 <p><a href="http://example.com" title="2 Words">space</a></p>
 <p><a href="http://example.com/url-(parentheses)" title="Title">parentheses</a></p>

--- a/test/data/inline_link_title.md
+++ b/test/data/inline_link_title.md
@@ -2,6 +2,10 @@
 
 [double quotes](http://example.com "Title")
 
+[single quotes blank](http://example.com '')
+
+[double quotes blank](http://example.com "")
+
 [space](http://example.com "2 Words")
 
 [parentheses](http://example.com/url-(parentheses) "Title")


### PR DESCRIPTION
This commit fixes an issue where blank titles in links and inline images result in the link not parsing from Markdown into HTML at all.  As mentioned on #283, some Markdown editors always insert a title even when it's blank.  In [our project](http://www.cerbweb.com/), we have thousands of knowledgebase articles with these blank titles in the Markdown, which previously worked with PHP Markdown and slightly earlier versions of Parsedown.

The issue stems from the regular expression for links that looks for "one or more characters that aren't a quote" instead of "zero or more characters that aren't quotes".

Similarly, it would be perfectly valid in HTML to have ```<a href="http://www.example.com" title=""></a>```, even though it's pointless.

I added additional tests for blank link titles using single and double quotes, and inline images using blank titles.
