### PR TITLE
Test on nightly releases of PHP (7.0) and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: php
 
 php:
+  - 7.0
   - 5.6
   - 5.5
   - 5.4
   - 5.3
   - hhvm
+  - hhvm-nightly
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.0
+    - php: hhvm-nightly


### PR DESCRIPTION
See https://github.com/erusev/parsedown/issues/294

See https://github.com/erusev/base/commit/12bf1c6d05e0ec89b1235078c6b5af3094422e0f#commitcomment-10090016

Nightly releases are allowed to fail since they are not stable and could fail in unpredictable ways.

New versions of PHP could be added as they are released.  I think they should not be in the allowed to fail part of the matrix then.