### PR TITLE
Remove "tested in PHP 5.2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Better Markdown Parser in PHP
 * [Fast](http://parsedown.org/speed)
 * [Consistent](http://parsedown.org/consistency)
 * [GitHub flavored](https://help.github.com/articles/github-flavored-markdown)
-* [Tested](http://parsedown.org/tests/) in PHP 5.2, 5.3, 5.4, 5.5, 5.6 and [hhvm](http://www.hhvm.com/)
+* [Tested](http://parsedown.org/tests/) in PHP 5.3, 5.4, 5.5, 5.6 and [hhvm](http://www.hhvm.com/)
 * [Extensible](https://github.com/erusev/parsedown/wiki/Writing-Extensions)
 * [Markdown Extra extension](https://github.com/erusev/parsedown-extra)
 


### PR DESCRIPTION
It is no longer tested on PHP 5.2 in Travis CI.

See https://github.com/erusev/parsedown/pull/286

[skip ci]