### PR TITLE
PHP 7 compatibility fixes

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -171,7 +171,7 @@ class Parsedown
 
             if (isset($CurrentBlock['incomplete']))
             {
-                $Block = $this->{'block'.$CurrentBlock['type'].'Continue'}($Line, $CurrentBlock);
+                $Block = call_user_func_array(array($this, 'block'.$CurrentBlock['type'].'Continue'), array($Line, $CurrentBlock));
 
                 if (isset($Block))
                 {
@@ -183,7 +183,7 @@ class Parsedown
                 {
                     if (method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
                     {
-                        $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+                        $CurrentBlock = call_user_func(array($this, 'block'.$CurrentBlock['type'].'Complete'), $CurrentBlock);
                     }
 
                     unset($CurrentBlock['incomplete']);
@@ -211,7 +211,7 @@ class Parsedown
 
             foreach ($blockTypes as $blockType)
             {
-                $Block = $this->{'block'.$blockType}($Line, $CurrentBlock);
+                $Block = call_user_func_array(array($this, 'block'.$blockType), array($Line, $CurrentBlock));
 
                 if (isset($Block))
                 {
@@ -255,7 +255,7 @@ class Parsedown
 
         if (isset($CurrentBlock['incomplete']) and method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
         {
-            $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+            $CurrentBlock = call_user_func(array($this, 'block'.$CurrentBlock['type'].'Complete'), $CurrentBlock);
         }
 
         # ~
@@ -1001,7 +1001,7 @@ class Parsedown
 
             foreach ($this->InlineTypes[$marker] as $inlineType)
             {
-                $Inline = $this->{'inline'.$inlineType}($Excerpt);
+                $Inline = call_user_func(array($this, 'inline'.$inlineType), $Excerpt);
 
                 if ( ! isset($Inline))
                 {
@@ -1402,7 +1402,7 @@ class Parsedown
 
             if (isset($Element['handler']))
             {
-                $markup .= $this->{$Element['handler']}($Element['text']);
+                $markup .= call_user_func(array($this, $Element['handler']), $Element['text']);
             }
             else
             {


### PR DESCRIPTION
Hi from the [Bolt CMS](http://bolt.cm) crew :wave: 

I'm working on getting us able to run on PHP 7 and found a compatibility issue with Parsedown:
```
PHP Fatal error: Function name must be a string
```

This PR resolves that by changing `$this->{$mystrin}` to use call_user_func() and call_user_func_array() instead.  

Passes the Parsedown PHPUnit tests on both PHP 5.x & 7