### PR TITLE
Make it possible to disable images

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -75,6 +75,16 @@ class Parsedown
 
     protected $urlsLinked = true;
 
+    function setImagesEnabled($imagesEnabled)
+    # Note: You should also set markupEscaped to disable images, otherwise people can still use <img> tags.
+    {
+        $this->imagesEnabled = $imagesEnabled;
+
+        return $this;
+    }
+
+    protected $imagesEnabled = true;
+
     #
     # Lines
     #
@@ -1136,7 +1146,7 @@ class Parsedown
 
     protected function inlineImage($Excerpt)
     {
-        if ( ! isset($Excerpt['text'][1]) or $Excerpt['text'][1] !== '[')
+        if ( ! isset($Excerpt['text'][1]) or $Excerpt['text'][1] !== '[' or ! $this->imagesEnabled )
         {
             return;
         }


### PR DESCRIPTION
Hello,

For privacy reasons, I do not want users adding images to markdown. For example, they could add 1px tracking GIF and it would be hard to spot. 

So I made a small change to make it possible to be disabled. If you use it make sure to also clean markup because they can still use `<img>`.