### PR TITLE
Add support for omitting line breaks.

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -75,6 +75,15 @@ class Parsedown
 
     protected $urlsLinked = true;
 
+	function setLineBreaks($lineBreaks)
+	{
+		$this->lineBreaks = $lineBreaks;
+
+		return $this;
+	}
+
+	protected $lineBreaks = true;
+
     #
     # Lines
     #
@@ -275,11 +284,17 @@ class Parsedown
                 continue;
             }
 
-            $markup .= "\n";
+			if ($this->lineBreaks)
+			{
+				$markup .= "\n";
+			}
             $markup .= isset($Block['markup']) ? $Block['markup'] : $this->element($Block['element']);
         }
 
-        $markup .= "\n";
+		if ($this->lineBreaks)
+		{
+			$markup .= "\n";
+		}
 
         # ~
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -75,14 +75,14 @@ class Parsedown
 
     protected $urlsLinked = true;
 
-	function setLineBreaks($lineBreaks)
-	{
-		$this->lineBreaks = $lineBreaks;
+    function setLineBreaks($lineBreaks)
+    {
+        $this->lineBreaks = $lineBreaks;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	protected $lineBreaks = true;
+    protected $lineBreaks = true;
 
     #
     # Lines
@@ -284,17 +284,17 @@ class Parsedown
                 continue;
             }
 
-			if ($this->lineBreaks)
-			{
-				$markup .= "\n";
-			}
+            if ($this->lineBreaks)
+            {
+                $markup .= "\n";
+            }
             $markup .= isset($Block['markup']) ? $Block['markup'] : $this->element($Block['element']);
         }
 
-		if ($this->lineBreaks)
-		{
-			$markup .= "\n";
-		}
+        if ($this->lineBreaks)
+        {
+            $markup .= "\n";
+        }
 
         # ~
 
@@ -1440,10 +1440,13 @@ class Parsedown
 
         foreach ($Elements as $Element)
         {
-            $markup .= "\n" . $this->element($Element);
+            $markup .= ($this->lineBreaks ? "\n" : '') . $this->element($Element);
         }
 
-        $markup .= "\n";
+        if ($this->lineBreaks)
+        {
+            $markup .= "\n";
+        }
 
         return $markup;
     }


### PR DESCRIPTION
Omitting line breaks has no effect on browsers, and helps save precious few bytes where possible. This pull request adds `setLineBreaks` function which allows developers to specify whether they want line breaks included or not. By default line breaks _are_ included, which is current behavior of the parser.

Line breaks are removed only after closing tags and in few other place where they shouldn't create any problem. `pre`, `tt` and `code` tags and their content are unaffected.