### PR TITLE
Fix check against $matches

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1212,7 +1212,7 @@ class Parsedown
         {
             if (preg_match('/^\s*\[(.*?)\]/', $remainder, $matches))
             {
-                $definition = $matches[1] ? $matches[1] : $Element['text'];
+                $definition = strlen($matches[1]) ? $matches[1] : $Element['text'];
                 $definition = strtolower($definition);
 
                 $extent += strlen($matches[0]);


### PR DESCRIPTION
Fixes inline reference links with int 0 as reference

The link [link][0] where [0] is set at the bottom of the md file current breaks and it's truthy value is false.