### PR TITLE
Added support of event listeners for blocks

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -323,7 +323,7 @@ class Parsedown
 
     /**
      * @param string $Event
-     *   Event name. All available events can be returned by {@link getUniqueBlockNames()} method.
+     *   Event name. All available events that can be returned by {@link getUniqueBlockNames()} method.
      * @param callable $Callback
      *   Callback function.
      * @param bool $Onetime
@@ -337,26 +337,27 @@ class Parsedown
      * @return self
      */
     public function addEventListener($Event, $Callback, $Onetime = false) {
-      $BlockTypes = array_flip($this->getUniqueBlockNames());
+        $BlockTypes = array_flip($this->getUniqueBlockNames());
 
-      if (!isset($BlockTypes[$Event]))
-      {
-          throw new \InvalidArgumentException(
-              sprintf('You trying to attach non-existent event. Available events are: "%s"', implode('", "', array_keys($BlockTypes)))
-          );
-      }
+        if (!isset($BlockTypes[$Event]))
+        {
+            throw new \InvalidArgumentException(sprintf(
+                'You trying to attach non-existent event. Available events are: "%s"',
+                implode('", "', array_keys($BlockTypes))
+            ));
+        }
 
-      if (!is_callable($Callback))
-      {
-          throw new \RuntimeException('Specified an invalid callback function!');
-      }
+        if (!is_callable($Callback))
+        {
+            throw new \RuntimeException('Invalid callback function was specified!');
+        }
 
-      $this->EventListeners[$Event][] = array(
-          'callback' => $Callback,
-          'onetime' => (bool) $Onetime,
-      );
+        $this->EventListeners[$Event][] = array(
+            'callback' => $Callback,
+            'onetime' => (bool) $Onetime,
+        );
 
-      return $this;
+        return $this;
     }
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -352,8 +352,8 @@ class Parsedown
       }
 
       $this->EventListeners[$Event][] = array(
-        'callback' => $Callback,
-        'onetime' => (bool) $Onetime,
+          'callback' => $Callback,
+          'onetime' => (bool) $Onetime,
       );
 
       return $this;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -470,6 +470,10 @@ class Parsedown
     {
         if (preg_match('/^(['.$Line['text'][0].']{3,})[ ]*([\w-]+)?[ ]*$/', $Line['text'], $matches))
         {
+            $Block = array(
+                'char' => $Line['text'][0],
+            );
+
             $Element = array(
                 'name' => 'code',
                 'text' => '',
@@ -477,15 +481,13 @@ class Parsedown
 
             if (isset($matches[2]))
             {
-                $class = 'language-'.$matches[2];
-
+                $Block['language'] = $matches[2];
                 $Element['attributes'] = array(
-                    'class' => $class,
+                    'class' => 'language-'.$matches[2],
                 );
             }
 
-            $Block = array(
-                'char' => $Line['text'][0],
+            $Block += array(
                 'element' => array(
                     'name' => 'pre',
                     'handler' => 'element',

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -488,11 +488,12 @@ class Parsedown
                 $class = 'language-'.$matches[1];
 
                 $Element['attributes'] = array(
-                  'class' => $class,
+                    'class' => $class,
                 );
             }
 
             $Block = array(
+                'char' => $Line['text'][0],
                 'element' => array(
                     'name' => 'pre',
                     'handler' => 'element',

--- a/README.md
+++ b/README.md
@@ -29,6 +29,43 @@ echo $Parsedown->text('Hello _Parsedown_!'); # prints: <p>Hello <em>Parsedown</e
 
 More examples in [the wiki](https://github.com/erusev/parsedown/wiki/Usage) and in [this video tutorial](http://youtu.be/wYZBY8DEikI).
 
+### Event listeners
+
+For example, you have a block with code in your MD syntax, but it not always present. May happen that you want to highlight it only when it exist. An event listener help you to do that.
+
+```php
+$Parsedown = new Parsedown();
+/**
+ * @param string $Event
+ *   Event name. All available events can be returned by {@link getUniqueBlockNames()} method.
+ * @param callable $Callback
+ *   Callback function.
+ * @param bool $Onetime
+ *   Execute callback function only once.
+ *
+ * @throws \InvalidArgumentException
+ *   When you trying to attach non-existent event.
+ * @throws \RuntimeException
+ *   When $Callback is not valid callback function.
+ *
+ * @return self
+ */
+$Parsedown->addEventListener('FencedCode', function (array $block) {
+    add_css_function('/highlight/styles/default.css');
+    add_js_function('/highlight/highlight.js');
+}, true);
+```
+
+Also, you can attach an event listener that will be executed on every block processing.
+
+```php
+$Parsedown = new Parsedown();
+// Set the "data-id=test" for each list element in HTML.
+$Parsedown->addEventListener('List', function (array &$block) {
+    $block['element']['attributes']['data-id'] = 'test';
+});
+```
+
 ### Questions
 
 **How does Parsedown work?**

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ $Parsedown->addEventListener('List', function (array &$block) {
 });
 ```
 
+Or, imagine that you need to colorize table rows.
+
+```php
+$Parsedown->addEventListener('Table', function (array &$block) {
+    $item = 0;
+
+    // thead and tbody.
+    foreach ($block['element']['text'] as &$section) {
+        // tr.
+        foreach ($section['text'] as &$rows) {
+            $rows['attributes']['class'] = $item++ % 2 ? 'odd' : 'even';
+        }
+    }
+});
+```
+
 ### Questions
 
 **How does Parsedown work?**


### PR DESCRIPTION
For each block, that converts to HTML, can be added an event listener - callback function with `$block` array as an argument. The one-time listeners are also supported.

Examples are available in modified `README.md`.
