### PR TITLE
Merge request for CommonMark compliance improvements

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -412,7 +412,7 @@ class Parsedown
 
     protected function blockFencedCode($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].']{3,})[ ]*([\w-]+)?[ ]*$/', $Line['text'], $matches))
+        if (preg_match('/^(['.$Line['text'][0].']{3,})\s*([\w-]+)?\s*$/', $Line['text'], $matches))
         {
             $Element = array(
                 'name' => 'code',
@@ -455,7 +455,7 @@ class Parsedown
             unset($Block['interrupted']);
         }
 
-        if (preg_match('/^'.$Block['char'].'{3,}[ ]*$/', $Line['text']))
+        if (preg_match('/^'.$Block['char'].'{3,}\s*$/', $Line['text']))
         {
             $Block['element']['text']['text'] = substr($Block['element']['text']['text'], 1);
 
@@ -520,7 +520,7 @@ class Parsedown
     {
         list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]+[.]');
 
-        if (preg_match('/^('.$pattern.'[ ]+)(.*)/', $Line['text'], $matches))
+        if (preg_match('/^('.$pattern.'\s+)(.*)/', $Line['text'], $matches))
         {
             $Block = array(
                 'indent' => $Line['indent'],
@@ -547,7 +547,7 @@ class Parsedown
 
     protected function blockListContinue($Line, array $Block)
     {
-        if ($Block['indent'] === $Line['indent'] and preg_match('/^'.$Block['pattern'].'(?:[ ]+(.*)|$)/', $Line['text'], $matches))
+        if ($Block['indent'] === $Line['indent'] and preg_match('/^'.$Block['pattern'].'(?:\s+(.*)|$)/', $Line['text'], $matches))
         {
             if (isset($Block['interrupted']))
             {
@@ -606,7 +606,7 @@ class Parsedown
 
     protected function blockQuote($Line)
     {
-        if (preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        if (preg_match('/^>\s?(.*)/', $Line['text'], $matches))
         {
             $Block = array(
                 'element' => array(
@@ -622,7 +622,7 @@ class Parsedown
 
     protected function blockQuoteContinue($Line, array $Block)
     {
-        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        if ($Line['text'][0] === '>' and preg_match('/^>\s?(.*)/', $Line['text'], $matches))
         {
             if (isset($Block['interrupted']))
             {
@@ -649,7 +649,7 @@ class Parsedown
 
     protected function blockRule($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].'])([ ]*\1){2,}[ ]*$/', $Line['text']))
+        if (preg_match('/^(['.$Line['text'][0].'])(\s*\1){2,}\s*$/', $Line['text']))
         {
             $Block = array(
                 'element' => array(
@@ -689,7 +689,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^<(\w*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
+        if (preg_match('/^<(\w*)(?:\s*'.$this->regexHtmlAttribute.')*\s*(\/)?>/', $Line['text'], $matches))
         {
             if (in_array($matches[1], $this->textLevelElements))
             {
@@ -722,7 +722,7 @@ class Parsedown
                     return;
                 }
 
-                if (preg_match('/<\/'.$matches[1].'>[ ]*$/i', $remainder))
+                if (preg_match('/<\/'.$matches[1].'>\s*$/i', $remainder))
                 {
                     $Block['closed'] = true;
                 }
@@ -739,12 +739,12 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^<'.$Block['name'].'(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*>/i', $Line['text'])) # open
+        if (preg_match('/^<'.$Block['name'].'(?:\s*'.$this->regexHtmlAttribute.')*\s*>/i', $Line['text'])) # open
         {
             $Block['depth'] ++;
         }
 
-        if (preg_match('/(.*?)<\/'.$Block['name'].'>[ ]*$/i', $Line['text'], $matches)) # close
+        if (preg_match('/(.*?)<\/'.$Block['name'].'>\s*$/i', $Line['text'], $matches)) # close
         {
             if ($Block['depth'] > 0)
             {
@@ -773,7 +773,7 @@ class Parsedown
 
     protected function blockReference($Line)
     {
-        if (preg_match('/^\[(.+?)\]:[ ]*<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*$/', $Line['text'], $matches))
+        if (preg_match('/^\[(.+?)\]:\s*<?(\S+?)>?(?:\s+["\'(](.+)["\')])?\s*$/', $Line['text'], $matches))
         {
             $id = strtolower($matches[1]);
 
@@ -1076,11 +1076,11 @@ class Parsedown
     {
         $marker = $Excerpt['text'][0];
 
-        if (preg_match('/^('.$marker.'+)[ ]*(.+?)[ ]*(?<!'.$marker.')\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
+        if (preg_match('/^('.$marker.'+)\s*(.+?)\s*(?<!'.$marker.')\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
         {
             $text = $matches[2];
             $text = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8');
-            $text = preg_replace("/[ ]*\n/", ' ', $text);
+            $text = preg_replace("/\s*\n/", ' ', $text);
 
             return array(
                 'extent' => strlen($matches[0]),
@@ -1222,7 +1222,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:[ ]+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
+        if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:\s+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
         {
             $Element['attributes']['href'] = $matches[1];
 
@@ -1273,7 +1273,7 @@ class Parsedown
             return;
         }
 
-        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w*[ ]*>/s', $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w*\s*>/s', $Excerpt['text'], $matches))
         {
             return array(
                 'markup' => $matches[0],
@@ -1289,7 +1289,7 @@ class Parsedown
             );
         }
 
-        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w*(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*\/?>/s', $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w*(?:\s*'.$this->regexHtmlAttribute.')*\s*\/?>/s', $Excerpt['text'], $matches))
         {
             return array(
                 'markup' => $matches[0],
@@ -1389,11 +1389,11 @@ class Parsedown
     {
         if ($this->breaksEnabled)
         {
-            $text = preg_replace('/[ ]*\n/', "<br />\n", $text);
+            $text = preg_replace('/\s*\n/', "<br />\n", $text);
         }
         else
         {
-            $text = preg_replace('/(?:[ ][ ]+|[ ]*\\\\)\n/', "<br />\n", $text);
+            $text = preg_replace('/(?:\s\s+|\s*\\\\)\n/', "<br />\n", $text);
             $text = str_replace(" \n", "\n", $text);
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -427,9 +427,9 @@ class Parsedown
                 'text' => '',
             );
 
-            if (isset($matches[1]))
+            if (isset($matches[2]))
             {
-                $class = 'language-'.$matches[1];
+                $class = 'language-'.$matches[2];
 
                 $Element['attributes'] = array(
                     'class' => $class,

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -649,7 +649,8 @@ class Parsedown
 
     protected function blockRule($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].'])(\s*\1){2,}\s*$/', $Line['text']))
+        if (($Line['indent']<4) and
+            preg_match('/^(['.$Line['text'][0].'])(\s*\1){2,}\s*$/', $Line['text']))
         {
             $Block = array(
                 'element' => array(

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -301,6 +301,8 @@ class Parsedown
             if ($text[$pos]==="\t"){
                 return substr($text,$pos+1);
             }
+            if($text[$pos]!==' ')
+                return substr($text,$pos);
         }
         return substr($text,4);
     }
@@ -578,7 +580,7 @@ class Parsedown
 
         if ( ! isset($Block['interrupted']))
         {
-            $text = preg_replace('/^[ ]{0,4}/', '', $Line['body']);
+            $text = $this->stripIndent($Line['body']);
 
             $Block['li']['text'] []= $text;
 
@@ -589,7 +591,7 @@ class Parsedown
         {
             $Block['li']['text'] []= '';
 
-            $text = preg_replace('/^[ ]{0,4}/', '', $Line['body']);
+            $text = $this->stripIndent($Line['body']);
 
             $Block['li']['text'] []= $text;
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -709,6 +709,13 @@ class Parsedown
                     return $Block;
                 }
             }
+            if (preg_match('/^<\/?(\w+)(\s[^>]*)?>$/', $Line['text'], $matches)){
+                $Block = array(
+                    'name' => $matches[1],
+                    'markup' => $Line['text'],
+                    );
+                return $Block;
+            }
             return;
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -700,7 +700,8 @@ class Parsedown
 
         if($this->commonMarkHtmlBlocks){
             if (preg_match('/^<\/?(\w+)((\s|>).*)?$/', $Line['text'], $matches)){
-                if(in_array(strtolower($matches[1]),$this->commonMarkHtmlElements))
+                if(in_array(strtolower($matches[1]),$this->commonMarkHtmlElements) or
+                   in_array(strtolower($matches[1]),$this->commonMarkLiteralHtmlElements))
                 {
                     $Block = array(
                         'name' => $matches[1],
@@ -775,7 +776,9 @@ class Parsedown
             {
                 unset($Block['interrupted']);
                 $Block['markup'] .= "\n";
-                return;
+                if(!in_array(strtolower($Block['name']),$this->commonMarkLiteralHtmlElements)){
+                    return;
+                }
             }
             $Block['markup'] .= "\n".$Line['text'];
             return $Block;
@@ -1591,6 +1594,11 @@ class Parsedown
         'tfoot', 'th', 'thead', 'title', 'tr', 'track', 'ul'
         );
 
+    protected $commonMarkLiteralHtmlElements = array(
+        'script','pre','style'
+        );
+
+    
     protected $textLevelElements = array(
         'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont',
         'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',

--- a/test/CommonMarkTest.php
+++ b/test/CommonMarkTest.php
@@ -22,6 +22,7 @@ class CommonMarkTest extends PHPUnit_Framework_TestCase
     {
         $Parsedown = new Parsedown();
         $Parsedown->setUrlsLinked(false);
+        $Parsedown->setTabsExpanded(false);
 
         $actualHtml = $Parsedown->text($markdown);
         $actualHtml = $this->normalizeMarkup($actualHtml);
@@ -48,6 +49,7 @@ class CommonMarkTest extends PHPUnit_Framework_TestCase
                     $markdown = preg_replace('/→/', "\t", $markdown);
                     $expectedHtml = $matches[2];
                     $expectedHtml = $this->normalizeMarkup($expectedHtml);
+                    $expectedHtml = preg_replace('/→/', "\t", $expectedHtml);
                     $tests []= array(
                         $currentSection, # section
                         $markdown, # markdown

--- a/test/CommonMarkTest.php
+++ b/test/CommonMarkTest.php
@@ -23,6 +23,7 @@ class CommonMarkTest extends PHPUnit_Framework_TestCase
         $Parsedown = new Parsedown();
         $Parsedown->setUrlsLinked(false);
         $Parsedown->setTabsExpanded(false);
+        $Parsedown->setCommonMarkHtmlBlocks(true);
 
         $actualHtml = $Parsedown->text($markdown);
         $actualHtml = $this->normalizeMarkup($actualHtml);


### PR DESCRIPTION
Hi,

I've been using ParseDown for some Markdown processing, and wanted to use some CommonMark features that weren't supported.

I've forked the repository and made some changes that improve the conformance to CommonMark. It would be great if you could merge them into the main Parsedown repo.

In order to avoid any breaking changes to existing users, the new features are only enabled when explicitly requested. To enable the preservation of tabs use:

```
$pd=new Parsedown();
$pd->setExpandedTabs(false);
```

To enable the CommonMark HTML block processing use:

```
$pd->setCommonMarkHtmlBlocks(true);
```

I hope you find this a useful patch.

Anthony
