### PR TITLE
Use late static binding for Parsedown::instance()

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1475,7 +1475,7 @@ class Parsedown
             return self::$instances[$name];
         }
 
-        $instance = new self();
+        $instance = new static();
 
         self::$instances[$name] = $instance;
 

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -136,4 +136,24 @@ EXPECTED_HTML;
         $parsedownWithNoMarkup->setMarkupEscaped(true);
         $this->assertEquals($expectedHtml, $parsedownWithNoMarkup->text($markdownWithHtml));
     }
+
+    public function testLateStaticBinding()
+    {
+        include 'test/TestParsedown.php';
+
+        $parsedown = Parsedown::instance();
+        $this->assertInstanceOf('Parsedown', $parsedown);
+
+        // After instance is already called on Parsedown
+        // subsequent calls with the same arguments return the same instance
+        $sameParsedown = TestParsedown::instance();
+        $this->assertInstanceOf('Parsedown', $sameParsedown);
+        $this->assertSame($parsedown, $sameParsedown);
+
+        $testParsedown = TestParsedown::instance('test late static binding');
+        $this->assertInstanceOf('TestParsedown', $testParsedown);
+
+        $sameInstanceAgain = TestParsedown::instance('test late static binding');
+        $this->assertSame($testParsedown, $sameInstanceAgain);
+    }
 }

--- a/test/TestParsedown.php
+++ b/test/TestParsedown.php
@@ -1,0 +1,5 @@
+<?php
+
+class TestParsedown extends Parsedown
+{
+}


### PR DESCRIPTION
Fixes erusev/parsedown-extra#67.

This introduces PHP 5.3+ late static binding to the Singleton pattern in Parsedown.
It will return an instance of Parsedown which inherits the class which called the `instance()` method rather than always returning instance of just `Parsedown`.

Tests are testing this feature with a test class which inherits from Parsedown.
Notice that calling `instance()` with the default arguments after an instance of `Parsedown` was already created, it will return it even though it is from just an instance of `Parsedown`. So this is fixing the problem just partially.