### PR TITLE
remove PHP 7.0 from allow failures in tests + improve readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.0
     - php: hhvm-nightly

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Better Markdown Parser in PHP
 * Super Fast
 * [GitHub flavored](https://help.github.com/articles/github-flavored-markdown)
 * Extensible
-* Tested in 5.3 to 5.6
+* Tested in 5.3 to 7.0 and in HHVM
 * [Markdown Extra extension](https://github.com/erusev/parsedown-extra)
 
 ### Installation


### PR DESCRIPTION
From history in Travis-CI I see that this library is stable for use with PHP 7.0. And PHP 7 is coming soon.. :-)