### PR TITLE
Simple changes to make Parsedown more pluggable

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -121,7 +121,7 @@ class Parsedown
     # Blocks
     #
 
-    private function lines(array $lines)
+    protected function lines(array $lines)
     {
         $CurrentBlock = null;
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -181,7 +181,7 @@ class Parsedown
                 }
                 else
                 {
-                    if (method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+                    if ($this->isBlockCompleteable($CurrentBlock['type']))
                     {
                         $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
                     }
@@ -224,7 +224,7 @@ class Parsedown
                         $Block['identified'] = true;
                     }
 
-                    if (method_exists($this, 'block'.$blockType.'Continue'))
+                    if ($this->isBlockContinueable($blockType))
                     {
                         $Block['incomplete'] = true;
                     }
@@ -253,7 +253,7 @@ class Parsedown
 
         # ~
 
-        if (isset($CurrentBlock['incomplete']) and method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+        if (isset($CurrentBlock['incomplete']) and $this->isBlockCompleteable($CurrentBlock['type']))
         {
             $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
         }
@@ -284,6 +284,20 @@ class Parsedown
         # ~
 
         return $markup;
+    }
+
+
+    #
+    # Allow for plugin extensibility
+    #
+    protected function isBlockContinueable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Continue');
+    }
+
+    protected function isBlockCompleteable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Complete');
     }
 
     #


### PR DESCRIPTION
An alternative and simpler approach to make Parsedown able to support plugins that extend functionality without requiring extending the class.  I outlined this approach in the comments of PR #340.

My approach is simpler and less invasive but allows for the ability to dynamically add methods to Parsedown by overriding the new `isBlockContinueable` and `isBlockCompleteable` methods.

In Parsedown itself, these will simply use the existing `method_exists()` check.  However in a 3rd party overridden class they can be extended to support other checks.