### PR TITLE
Simple changes to make Parsedown more pluggable

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -175,7 +175,7 @@ class Parsedown
                 }
                 else
                 {
-                    if ($this->isBlockCompleteable($CurrentBlock['type']))
+                    if ($this->isBlockCompletable($CurrentBlock['type']))
                     {
                         $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
                     }
@@ -216,7 +216,7 @@ class Parsedown
                         $Block['identified'] = true;
                     }
 
-                    if ($this->isBlockContinueable($blockType))
+                    if ($this->isBlockContinuable($blockType))
                     {
                         $Block['continuable'] = true;
                     }
@@ -245,7 +245,7 @@ class Parsedown
 
         # ~
 
-        if (isset($CurrentBlock['continuable']) and $this->isBlockCompleteable($CurrentBlock['type']))
+        if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
         {
             $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
         }
@@ -281,12 +281,12 @@ class Parsedown
     #
     # Allow for plugin extensibility
     #
-    protected function isBlockContinueable($Type)
+    protected function isBlockContinuable($Type)
     {
         return method_exists($this, 'block'.$Type.'Continue');
     }
 
-    protected function isBlockCompleteable($Type)
+    protected function isBlockCompletable($Type)
     {
         return method_exists($this, 'block'.$Type.'Complete');
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -115,7 +115,7 @@ class Parsedown
     # Blocks
     #
 
-    private function lines(array $lines)
+    protected function lines(array $lines)
     {
         $CurrentBlock = null;
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1534,8 +1534,8 @@ class Parsedown
         'q', 'rt', 'ins', 'font',          'strong',
         's', 'tt', 'sub', 'mark',
         'u', 'xm', 'sup', 'nobr',
-        'var', 'ruby',
-        'wbr', 'span',
-        'time',
+                   'var', 'ruby',
+                   'wbr', 'span',
+                          'time',
     );
 }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -175,7 +175,7 @@ class Parsedown
                 }
                 else
                 {
-                    if (method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+                    if ($this->isBlockCompleteable($CurrentBlock['type']))
                     {
                         $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
                     }
@@ -216,7 +216,7 @@ class Parsedown
                         $Block['identified'] = true;
                     }
 
-                    if (method_exists($this, 'block'.$blockType.'Continue'))
+                    if ($this->isBlockContinueable($blockType))
                     {
                         $Block['continuable'] = true;
                     }
@@ -245,7 +245,7 @@ class Parsedown
 
         # ~
 
-        if (isset($CurrentBlock['continuable']) and method_exists($this, 'block'.$CurrentBlock['type'].'Complete'))
+        if (isset($CurrentBlock['continuable']) and $this->isBlockCompleteable($CurrentBlock['type']))
         {
             $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
         }
@@ -276,6 +276,19 @@ class Parsedown
         # ~
 
         return $markup;
+    }
+
+    #
+    # Allow for plugin extensibility
+    #
+    protected function isBlockContinueable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Continue');
+    }
+
+    protected function isBlockCompleteable($Type)
+    {
+        return method_exists($this, 'block'.$Type.'Complete');
     }
 
     #
@@ -1521,8 +1534,8 @@ class Parsedown
         'q', 'rt', 'ins', 'font',          'strong',
         's', 'tt', 'sub', 'mark',
         'u', 'xm', 'sup', 'nobr',
-                   'var', 'ruby',
-                   'wbr', 'span',
-                          'time',
+        'var', 'ruby',
+        'wbr', 'span',
+        'time',
     );
 }


### PR DESCRIPTION
An alternative and simpler approach to make Parsedown able to support plugins that extend functionality without requiring extending the class.  I outlined this approach in the comments of PR #340.

My approach is simpler and less invasive but allows for the ability to dynamically add methods to Parsedown by overriding the new `isBlockContinueable` and `isBlockCompleteable` methods.

In Parsedown itself, these will simply use the existing `method_exists()` check.  However in a 3rd party overridden class they can be extended to support other checks.