### PR TITLE
Support for opening links in new tabs/windows

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1212,7 +1212,14 @@ class Parsedown
 
         if (preg_match('/^[(]((?:[^ ()]|[(][^ )]+[)])+)(?:[ ]+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
         {
-            $Element['attributes']['href'] = $matches[1];
+            $TentativeHRef = $matches[1];
+            if ($TentativeHRef[0] == "+")
+            {
+				$Element['attributes']['target'] = "_blank";
+				$Element['attributes']['href'] = substr($TentativeHRef, 1);
+            }	else	{
+	            $Element['attributes']['href'] = $TentativeHRef;
+	        }
 
             if (isset($matches[2]))
             {


### PR DESCRIPTION
I needed a simple Markdown syntax modification for potentially opening links in new tabs/windows.
If you add a '+' sign just before the http link there's a "target='_blank'" attribute added to a HTML A element.
Yes, it's a Markdown syntax modification...