### PR TITLE
Add hook functionality

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1501,7 +1501,7 @@ class Parsedown
     {
         foreach ($this->hooks as $hook) {
             if (method_exists($hook, $methodName)) {
-                $return = $hook::$methodName($return);
+                $return = $hook->$methodName($return);
             }
         }
 
@@ -1544,7 +1544,7 @@ class Parsedown
     public function registerHook($className = NULL)
     {
         if (class_exists($className)) {
-            $this->hooks[] = $className;
+            $this->hooks[] = new $className($this);
         }
 
         return $this;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1501,7 +1501,7 @@ class Parsedown
     {
         foreach (self::$hooks as $hook) {
             if (method_exists($hook, $methodName)) {
-                return $hook::$methodName($return);
+                $return = $hook::$methodName($return);
             }
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -283,12 +283,14 @@ class Parsedown
     #
     protected function isBlockContinuable($Type)
     {
-        return method_exists($this, 'block'.$Type.'Continue');
+        $return = method_exists($this, 'block'.$Type.'Continue');
+        return $this->runHooks(__FUNCTION__, $return);
     }
 
     protected function isBlockCompletable($Type)
     {
-        return method_exists($this, 'block'.$Type.'Complete');
+        $return = method_exists($this, 'block'.$Type.'Complete');
+        return $this->runHooks(__FUNCTION__, $return);
     }
 
     #
@@ -1538,6 +1540,36 @@ class Parsedown
     }
 
     /**
+     * @param Array $blockType
+     * @return Array $BlockTypes
+     */
+    public function addBlockType(array $blockType)
+    {
+        $this->BlockTypes[] = $blockType;
+        return $this->BlockTypes;
+    }
+
+    /**
+     * @param String $unmarkedBlockType
+     * @return Array $UnmarkedBlockTypes
+     */
+    public function addUnmarkedBlockType($unmarkedBlockType)
+    {
+        $this->UnmarkedBlockTypes[] = $unmarkedBlockType;
+        return $this->UnmarkedBlockTypes;
+    }
+
+    /**
+     * @param Array $inlineType
+     * @return Array $InlineTypes
+     */
+    public function addInlineType(array $inlineType)
+    {
+        $this->InlineTypes[] = $inlineType;
+        return $this->InlineTypes;
+    }
+
+    /**
      * Registers a hook class
      * @param String $className
      */
@@ -1547,7 +1579,7 @@ class Parsedown
             $this->hooks[] = new $className($this);
         }
 
-        return $this;
+        return end($this->hooks);
     }
 
     private $hooks = array();

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1499,7 +1499,7 @@ class Parsedown
      */
     protected function runHooks($methodName, $return)
     {
-        foreach (self::$hooks as $hook) {
+        foreach ($this->hooks as $hook) {
             if (method_exists($hook, $methodName)) {
                 $return = $hook::$methodName($return);
             }
@@ -1541,14 +1541,16 @@ class Parsedown
      * Registers a hook class
      * @param String $className
      */
-    static function registerHook($className = NULL)
+    public function registerHook($className = NULL)
     {
         if (class_exists($className)) {
-            self::$hooks[] = $className;
+            $this->hooks[] = $className;
         }
+
+        return $this;
     }
 
-    private static $hooks = array();
+    private $hooks = array();
 
     private static $instances = array();
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1577,9 +1577,10 @@ class Parsedown
     {
         if (class_exists($className)) {
             $this->hooks[] = new $className($this);
+            return end($this->hooks);
         }
 
-        return end($this->hooks);
+        return FALSE;
     }
 
     private $hooks = array();

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1494,7 +1494,7 @@ class Parsedown
     /**
      * Called in each method which supports hooks.
      * @param String method name
-     * @param Mixed arguments passed in the original method
+     * @param Mixed return value from original method
      * @return Mixed return value passed through the hook method
      */
     protected function runHooks($methodName, $return)

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -41,7 +41,7 @@ class Parsedown
         # trim line breaks
         $markup = trim($markup, "\n");
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
     }
 
     #
@@ -275,7 +275,7 @@ class Parsedown
 
         # ~
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
     }
 
     #
@@ -316,7 +316,7 @@ class Parsedown
                 ),
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -337,7 +337,7 @@ class Parsedown
 
             $Block['element']['text']['text'] .= $text;
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -349,7 +349,7 @@ class Parsedown
 
         $Block['element']['text']['text'] = $text;
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     #
@@ -373,7 +373,7 @@ class Parsedown
                 $Block['closed'] = true;
             }
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -391,7 +391,7 @@ class Parsedown
             $Block['closed'] = true;
         }
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     #
@@ -424,7 +424,7 @@ class Parsedown
                 ),
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -448,12 +448,12 @@ class Parsedown
 
             $Block['complete'] = true;
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
 
         $Block['element']['text']['text'] .= "\n".$Line['body'];;
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     protected function blockFencedCodeComplete($Block)
@@ -464,7 +464,7 @@ class Parsedown
 
         $Block['element']['text']['text'] = $text;
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     #
@@ -496,7 +496,7 @@ class Parsedown
                 ),
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -528,7 +528,7 @@ class Parsedown
 
             $Block['element']['text'] []= & $Block['li'];
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -557,12 +557,12 @@ class Parsedown
 
             $Block['element']['text'] []= & $Block['li'];
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
 
         if ($Line['text'][0] === '[' and $this->blockReference($Line))
         {
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
 
         if ( ! isset($Block['interrupted']))
@@ -571,7 +571,7 @@ class Parsedown
 
             $Block['li']['text'] []= $text;
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
 
         if ($Line['indent'] > 0)
@@ -584,7 +584,7 @@ class Parsedown
 
             unset($Block['interrupted']);
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -603,7 +603,7 @@ class Parsedown
                 ),
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -620,14 +620,14 @@ class Parsedown
 
             $Block['element']['text'] []= $matches[1];
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
 
         if ( ! isset($Block['interrupted']))
         {
             $Block['element']['text'] []= $Line['text'];
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -644,7 +644,7 @@ class Parsedown
                 ),
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -662,7 +662,7 @@ class Parsedown
         {
             $Block['element']['name'] = $Line['text'][0] === '=' ? 'h1' : 'h2';
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -717,7 +717,7 @@ class Parsedown
                 }
             }
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -754,7 +754,7 @@ class Parsedown
 
         $Block['markup'] .= "\n".$Line['body'];
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     #
@@ -782,7 +782,7 @@ class Parsedown
                 'hidden' => true,
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -892,7 +892,7 @@ class Parsedown
                 'text' => $HeaderElements,
             );
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -942,7 +942,7 @@ class Parsedown
 
             $Block['element']['text'][1]['text'] []= $Element;
 
-            return $Block;
+            return $this->runHooks(__FUNCTION__, $Block);
         }
     }
 
@@ -960,7 +960,7 @@ class Parsedown
             ),
         );
 
-        return $Block;
+        return $this->runHooks(__FUNCTION__, $Block);
     }
 
     #
@@ -1053,7 +1053,7 @@ class Parsedown
 
         $markup .= $this->unmarkedText($text);
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
     }
 
     #
@@ -1070,13 +1070,15 @@ class Parsedown
             $text = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8');
             $text = preg_replace("/[ ]*\n/", ' ', $text);
 
-            return array(
+            $return = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(
                     'name' => 'code',
                     'text' => $text,
                 ),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1091,7 +1093,7 @@ class Parsedown
                 $url = 'mailto:' . $url;
             }
 
-            return array(
+            $return = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(
                     'name' => 'a',
@@ -1101,6 +1103,8 @@ class Parsedown
                     ),
                 ),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1126,7 +1130,7 @@ class Parsedown
             return;
         }
 
-        return array(
+        $return = array(
             'extent' => strlen($matches[0]),
             'element' => array(
                 'name' => $emphasis,
@@ -1134,16 +1138,20 @@ class Parsedown
                 'text' => $matches[1],
             ),
         );
+
+        return $this->runHooks(__FUNCTION__, $return);
     }
 
     protected function inlineEscapeSequence($Excerpt)
     {
         if (isset($Excerpt['text'][1]) and in_array($Excerpt['text'][1], $this->specialCharacters))
         {
-            return array(
+            $return = array(
                 'markup' => $Excerpt['text'][1],
                 'extent' => 2,
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1178,7 +1186,7 @@ class Parsedown
 
         unset($Inline['element']['attributes']['href']);
 
-        return $Inline;
+        return $this->runHooks(__FUNCTION__, $Inline);
     }
 
     protected function inlineLink($Excerpt)
@@ -1248,10 +1256,12 @@ class Parsedown
 
         $Element['attributes']['href'] = str_replace(array('&', '<'), array('&amp;', '&lt;'), $Element['attributes']['href']);
 
-        return array(
+        $return = array(
             'extent' => $extent,
             'element' => $Element,
         );
+
+        return $this->runHooks(__FUNCTION__, $return);
     }
 
     protected function inlineMarkup($Excerpt)
@@ -1263,26 +1273,32 @@ class Parsedown
 
         if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w*[ ]*>/s', $Excerpt['text'], $matches))
         {
-            return array(
+            $return = array(
                 'markup' => $matches[0],
                 'extent' => strlen($matches[0]),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
 
         if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?[^-])*-->/s', $Excerpt['text'], $matches))
         {
-            return array(
+            $return = array(
                 'markup' => $matches[0],
                 'extent' => strlen($matches[0]),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
 
         if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w*(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*\/?>/s', $Excerpt['text'], $matches))
         {
-            return array(
+            $return = array(
                 'markup' => $matches[0],
                 'extent' => strlen($matches[0]),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1290,20 +1306,24 @@ class Parsedown
     {
         if ($Excerpt['text'][0] === '&' and ! preg_match('/^&#?\w+;/', $Excerpt['text']))
         {
-            return array(
+            $return = array(
                 'markup' => '&amp;',
                 'extent' => 1,
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
 
         $SpecialCharacter = array('>' => 'gt', '<' => 'lt', '"' => 'quot');
 
         if (isset($SpecialCharacter[$Excerpt['text'][0]]))
         {
-            return array(
+            $return = array(
                 'markup' => '&'.$SpecialCharacter[$Excerpt['text'][0]].';',
                 'extent' => 1,
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1316,7 +1336,7 @@ class Parsedown
 
         if ($Excerpt['text'][1] === '~' and preg_match('/^~~(?=\S)(.+?)(?<=\S)~~/', $Excerpt['text'], $matches))
         {
-            return array(
+            $return = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(
                     'name' => 'del',
@@ -1324,6 +1344,8 @@ class Parsedown
                     'handler' => 'line',
                 ),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1348,7 +1370,7 @@ class Parsedown
                 ),
             );
 
-            return $Inline;
+            return $this->runHooks(__FUNCTION__, $Inline);
         }
     }
 
@@ -1358,7 +1380,7 @@ class Parsedown
         {
             $url = str_replace(array('&', '<'), array('&amp;', '&lt;'), $matches[1]);
 
-            return array(
+            $return = array(
                 'extent' => strlen($matches[0]),
                 'element' => array(
                     'name' => 'a',
@@ -1368,6 +1390,8 @@ class Parsedown
                     ),
                 ),
             );
+
+            return $this->runHooks(__FUNCTION__, $return);
         }
     }
 
@@ -1385,7 +1409,7 @@ class Parsedown
             $text = str_replace(" \n", "\n", $text);
         }
 
-        return $text;
+        return $this->runHooks(__FUNCTION__, $text);
     }
 
     #
@@ -1429,7 +1453,7 @@ class Parsedown
             $markup .= ' />';
         }
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
     }
 
     protected function elements(array $Elements)
@@ -1443,7 +1467,7 @@ class Parsedown
 
         $markup .= "\n";
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
     }
 
     # ~
@@ -1464,7 +1488,24 @@ class Parsedown
             $markup = substr_replace($markup, '', $position, 4);
         }
 
-        return $markup;
+        return $this->runHooks(__FUNCTION__, $markup);
+    }
+
+    /**
+     * Called in each method which supports hooks.
+     * @param String method name
+     * @param Mixed arguments passed in the original method
+     * @return Mixed return value passed through the hook method
+     */
+    protected function runHooks($methodName, $return)
+    {
+        foreach (self::$hooks as $hook) {
+            if (method_exists($hook, $methodName)) {
+                return $hook::$methodName($return);
+            }
+        }
+
+        return $return;
     }
 
     #
@@ -1495,6 +1536,19 @@ class Parsedown
 
         return $instance;
     }
+
+    /**
+     * Registers a hook class
+     * @param String $className
+     */
+    static function registerHook($className = NULL)
+    {
+        if (class_exists($className)) {
+            self::$hooks[] = $className;
+        }
+    }
+
+    private static $hooks = array();
 
     private static $instances = array();
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ you would like to modify the output.  Then register the class with Parsedown.
 ``` php
 class HookExample
 {
-	public static function inlineUrl($url) {
+	public function inlineUrl($url) {
 		$url['element']['attributes']['rel'] = 'nofollow';
 		return $url;
 	}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ $Parsedown = new Parsedown();
 echo $Parsedown->text('Hello _Parsedown_!'); # prints: <p>Hello <em>Parsedown</em>!</p>
 ```
 
+### Example Hook
+This fork adds hook functionality.  To use, write a class that declares static methods with the same name as the methods which 
+you would like to modify the output.  Then register the class with Parsedown.
+``` php
+class HookExample
+{
+	public static function inlineUrl($url) {
+		$url['element']['attributes']['rel'] = 'nofollow';
+		return $url;
+	}
+}
+
+Parsedown::registerHook('HookExample');
+```
+
 More examples in [the wiki](https://github.com/erusev/parsedown/wiki/) and in [this video tutorial](http://youtu.be/wYZBY8DEikI).
 
 ### Questions

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ $Parsedown = new Parsedown();
 
 echo $Parsedown->text('Hello _Parsedown_!'); # prints: <p>Hello <em>Parsedown</em>!</p>
 ```
+More examples in [the wiki](https://github.com/erusev/parsedown/wiki/) and in [this video tutorial](http://youtu.be/wYZBY8DEikI).
+
 
 ### Hooks
-This fork adds hook functionality that allows you to extend Parsedown.  To use, write a class that declares static methods with the same name as the methods which 
+You can write hooks that extend Parsedown's functionality.  To use, write a class that declares static methods with the same name as the methods which 
 you would like to modify the output.  Then register the class with Parsedown.
 #### Hook Example
 ``` php
@@ -45,10 +47,11 @@ class HookExample
 	}
 }
 
-Parsedown::registerHook('HookExample');
+$Parsedown = new Parsedown;
+$Parsedown->registerHook('HookExample');
+echo $Parsedown->text('http://google.com');
 ```
 
-More examples in [the wiki](https://github.com/erusev/parsedown/wiki/) and in [this video tutorial](http://youtu.be/wYZBY8DEikI).
 
 ### Questions
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ $Parsedown = new Parsedown();
 echo $Parsedown->text('Hello _Parsedown_!'); # prints: <p>Hello <em>Parsedown</em>!</p>
 ```
 
-### Example Hook
-This fork adds hook functionality.  To use, write a class that declares static methods with the same name as the methods which 
+### Hooks
+This fork adds hook functionality that allows you to extend Parsedown.  To use, write a class that declares static methods with the same name as the methods which 
 you would like to modify the output.  Then register the class with Parsedown.
+#### Hook Example
 ``` php
 class HookExample
 {


### PR DESCRIPTION
Adds hook functionality that allows you to extend Parsedown without having to extend the core class. To use, write a class that declares methods with the same name as the methods which you would like to modify the output of. Then register the class with Parsedown.

``` php
class HookExample
{
    public function inlineUrl($url) {
        $url['element']['attributes']['rel'] = 'nofollow';
        return $url;
    }
}

$Parsedown = new Parsedown;
$Parsedown->registerHook('HookExample');
echo $Parsedown->text('http://google.com');
```
