### PR TITLE
Remove & from being replaced with &amp; in inline links

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1243,7 +1243,7 @@ class Parsedown
             $Element['attributes']['title'] = $Definition['title'];
         }
 
-        $Element['attributes']['href'] = str_replace(array('&', '<'), array('&amp;', '&lt;'), $Element['attributes']['href']);
+        $Element['attributes']['href'] = str_replace('<', '&lt;', $Element['attributes']['href']);
 
         return array(
             'extent' => $extent,


### PR DESCRIPTION
Currently the `&` is converted into `&amp;` in an inline link

`[this is my site](https://example.com/site?param1=1&param2=2)`

is converted into

`<a href="https://example.com/site?param1=1&amp;param2=2">this is my site</a>`.

I think it should be fine to simply remove that.