### PR TITLE
Don't create pair tags without content

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1410,13 +1410,24 @@ class Parsedown
         {
             $markup .= '>';
 
+            $elementContent = '';
             if (isset($Element['handler']))
             {
-                $markup .= $this->{$Element['handler']}($Element['text']);
+                $elementContent .= $this->{$Element['handler']}($Element['text']);
             }
             else
             {
-                $markup .= $Element['text'];
+                $elementContent .= $Element['text'];
+            }
+
+            if (!empty($elementContent))
+            {
+                $markup .= $elementContent;
+            }
+            else
+            {
+                // Element has set $Element['text'] but no content, so don't return this useless empty tag.
+                return '';
             }
 
             $markup .= '</'.$Element['name'].'>';


### PR DESCRIPTION
This commit fix empty `<p>` tags after parsing markdown with custom extensions like this: https://gist.github.com/integer/05dea90948c4e96a254bb2508151d1ef
