### PR TITLE
Fix Issue #358 – preventing double nested links

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -987,7 +987,7 @@ class Parsedown
     # ~
     #
 
-    public function line($text, $non_nestables=array())
+    public function line($text, $nonNestables=array())
     {
         $markup = '';
 
@@ -1005,7 +1005,7 @@ class Parsedown
             {
                 # check to see if the current inline type is nestable in the current context
 
-                if ( ! empty($non_nestables) and in_array($inlineType, $non_nestables))
+                if ( ! empty($nonNestables) and in_array($inlineType, $nonNestables))
                 {
                     continue;
                 }
@@ -1033,9 +1033,9 @@ class Parsedown
 
                 # cause the new element to 'inherit' our non nestables
 
-                foreach ($non_nestables as $non_nestable)
+                foreach ($nonNestables as $non_nestable)
                 {
-                    $Inline['element']['non_nestables'][] = $non_nestable;
+                    $Inline['element']['nonNestables'][] = $non_nestable;
                 }
 
                 # the text that comes before the inline
@@ -1197,7 +1197,7 @@ class Parsedown
         $Element = array(
             'name' => 'a',
             'handler' => 'line',
-            'non_nestables' => array('Url', 'Link'),
+            'nonNestables' => array('Url', 'Link'),
             'text' => null,
             'attributes' => array(
                 'href' => null,
@@ -1425,14 +1425,14 @@ class Parsedown
         {
             $markup .= '>';
 
-            if (!isset($Element['non_nestables'])) 
+            if (!isset($Element['nonNestables'])) 
             {
-                $Element['non_nestables'] = array();
+                $Element['nonNestables'] = array();
             }
 
             if (isset($Element['handler']))
             {
-                $markup .= $this->{$Element['handler']}($Element['text'], $Element['non_nestables']);
+                $markup .= $this->{$Element['handler']}($Element['text'], $Element['nonNestables']);
             }
             else
             {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -987,7 +987,7 @@ class Parsedown
     # ~
     #
 
-    public function line($text)
+    public function line($text, $non_nestables=array())
     {
         $markup = '';
 
@@ -1003,6 +1003,12 @@ class Parsedown
 
             foreach ($this->InlineTypes[$marker] as $inlineType)
             {
+                
+                if(in_array($inlineType, $non_nestables))
+                {
+                    continue;
+                }
+
                 $Inline = $this->{'inline'.$inlineType}($Excerpt);
 
                 if ( ! isset($Inline))
@@ -1183,6 +1189,7 @@ class Parsedown
         $Element = array(
             'name' => 'a',
             'handler' => 'line',
+            'non_nestables' => array('Url', 'Link'),
             'text' => null,
             'attributes' => array(
                 'href' => null,
@@ -1410,9 +1417,11 @@ class Parsedown
         {
             $markup .= '>';
 
+            if(!isset($Element['non_nestables'])) $Element['non_nestables'] = array();
+
             if (isset($Element['handler']))
             {
-                $markup .= $this->{$Element['handler']}($Element['text']);
+                $markup .= $this->{$Element['handler']}($Element['text'], $Element['non_nestables']);
             }
             else
             {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1003,22 +1003,19 @@ class Parsedown
 
             foreach ($this->InlineTypes[$marker] as $inlineType)
             {
+                # check to see if the current inline type is nestable in the current context
+
                 foreach ($non_nestables as $key => $non_nestable)
                 {
-                    if (is_array($non_nestable))
+                    # case that we used array syntax 
+                    if (is_array($non_nestable) and $non_nestable[0] === $inlineType)
                     {
-                        
-                        if ($non_nestable[0] === $inlineType)
-                        {
-                            continue 2;
-                        }
+                        continue 2;
                     }
-                    else
+                    # case that we used plain string syntax
+                    elseif ( ! is_array($non_nestable) and $non_nestable === $inlineType)
                     {
-                        if ($non_nestable === $inlineType)
-                        {
-                            continue 2;
-                        }
+                        continue 2;
                     }
                 }
 
@@ -1043,25 +1040,27 @@ class Parsedown
                     $Inline['position'] = $markerPosition;
                 }
 
+                # cause the new element to 'inherit' our non nestables, if appropriate
+
                 foreach ($non_nestables as $key => $non_nestable)
                 {
-                    if (is_array($non_nestable) && isset($non_nestable[1]) && is_int($non_nestable[1])){
-                        if($non_nestable[1] > 1)
-                        {
-                            $Inline['element']['non_nestables'][] = array($non_nestable[0], $non_nestable[1] -1);
-                        }
-                        
+                    # array syntax, and depth is sufficient to pass on
+                    if (is_array($non_nestable) and isset($non_nestable[1]) and
+                        is_int($non_nestable[1]) and $non_nestable[1] > 1)
+                    {
+                        $Inline['element']['non_nestables'][] = array($non_nestable[0], $non_nestable[1] -1);
                     }
-                    elseif (is_array($non_nestable) && ! isset($non_nestable[1]))
+                    # array syntax, and depth is indefinite
+                    elseif (is_array($non_nestable) and ! isset($non_nestable[1]))
                     {
                          $Inline['element']['non_nestables'][] = array($non_nestable[0]);
                     }
+                    # string syntax, so depth is indefinite
                     elseif ( ! is_array($non_nestable))
                     {
                         $Inline['element']['non_nestables'][] = $non_nestable;
                     }
                 }
-                
 
                 # the text that comes before the inline
                 $unmarkedText = substr($text, 0, $Inline['position']);
@@ -1450,7 +1449,10 @@ class Parsedown
         {
             $markup .= '>';
 
-            if(!isset($Element['non_nestables'])) $Element['non_nestables'] = array();
+            if (!isset($Element['non_nestables'])) 
+            {
+                $Element['non_nestables'] = array();
+            }
 
             if (isset($Element['handler']))
             {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1003,10 +1003,23 @@ class Parsedown
 
             foreach ($this->InlineTypes[$marker] as $inlineType)
             {
-                
-                if(in_array($inlineType, $non_nestables))
+                foreach ($non_nestables as $key => $non_nestable)
                 {
-                    continue;
+                    if (is_array($non_nestable))
+                    {
+                        
+                        if ($non_nestable[0] === $inlineType)
+                        {
+                            continue 2;
+                        }
+                    }
+                    else
+                    {
+                        if ($non_nestable === $inlineType)
+                        {
+                            continue 2;
+                        }
+                    }
                 }
 
                 $Inline = $this->{'inline'.$inlineType}($Excerpt);
@@ -1029,6 +1042,26 @@ class Parsedown
                 {
                     $Inline['position'] = $markerPosition;
                 }
+
+                foreach ($non_nestables as $key => $non_nestable)
+                {
+                    if (is_array($non_nestable) && isset($non_nestable[1]) && is_int($non_nestable[1])){
+                        if($non_nestable[1] > 1)
+                        {
+                            $Inline['element']['non_nestables'][] = array($non_nestable[0], $non_nestable[1] -1);
+                        }
+                        
+                    }
+                    elseif (is_array($non_nestable) && ! isset($non_nestable[1]))
+                    {
+                         $Inline['element']['non_nestables'][] = array($non_nestable[0]);
+                    }
+                    elseif ( ! is_array($non_nestable))
+                    {
+                        $Inline['element']['non_nestables'][] = $non_nestable;
+                    }
+                }
+                
 
                 # the text that comes before the inline
                 $unmarkedText = substr($text, 0, $Inline['position']);

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1005,18 +1005,9 @@ class Parsedown
             {
                 # check to see if the current inline type is nestable in the current context
 
-                foreach ($non_nestables as $key => $non_nestable)
+                if (in_array($inlineType, $non_nestables))
                 {
-                    # case that we used array syntax 
-                    if (is_array($non_nestable) and $non_nestable[0] === $inlineType)
-                    {
-                        continue 2;
-                    }
-                    # case that we used plain string syntax
-                    elseif ( ! is_array($non_nestable) and $non_nestable === $inlineType)
-                    {
-                        continue 2;
-                    }
+                    continue;
                 }
 
                 $Inline = $this->{'inline'.$inlineType}($Excerpt);
@@ -1040,26 +1031,11 @@ class Parsedown
                     $Inline['position'] = $markerPosition;
                 }
 
-                # cause the new element to 'inherit' our non nestables, if appropriate
+                # cause the new element to 'inherit' our non nestables
 
-                foreach ($non_nestables as $key => $non_nestable)
+                foreach ($non_nestables as $non_nestable)
                 {
-                    # array syntax, and depth is sufficient to pass on
-                    if (is_array($non_nestable) and isset($non_nestable[1]) and
-                        is_int($non_nestable[1]) and $non_nestable[1] > 1)
-                    {
-                        $Inline['element']['non_nestables'][] = array($non_nestable[0], $non_nestable[1] -1);
-                    }
-                    # array syntax, and depth is indefinite
-                    elseif (is_array($non_nestable) and ! isset($non_nestable[1]))
-                    {
-                         $Inline['element']['non_nestables'][] = array($non_nestable[0]);
-                    }
-                    # string syntax, so depth is indefinite
-                    elseif ( ! is_array($non_nestable))
-                    {
-                        $Inline['element']['non_nestables'][] = $non_nestable;
-                    }
+                    $Inline['element']['non_nestables'][] = $non_nestable;
                 }
 
                 # the text that comes before the inline

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1005,7 +1005,7 @@ class Parsedown
             {
                 # check to see if the current inline type is nestable in the current context
 
-                if (in_array($inlineType, $non_nestables))
+                if ( ! empty($non_nestables) and in_array($inlineType, $non_nestables))
                 {
                     continue;
                 }


### PR DESCRIPTION
1. Add the ability for a parsed element to enforce that the line handler not parse any (immediate) child elements of a specified type.
2. Use 1. to allow parsed Link elements to tell the line handler not to parse any child Links or Urls where they are immediate children.
