### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - nightly
   - 7.1
   - 7.0
   - 5.6
@@ -8,9 +9,8 @@ php:
   - 5.4
   - 5.3
   - hhvm
-  - hhvm-nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm-nightly
+    - php: nightly


### PR DESCRIPTION
followup to #436
- `hhvm-nightly` is not longer supported by travis: https://travis-ci.org/erusev/parsedown/jobs/167116493
- Added `nightly` which builds from PHP master. It is different from 7.1 as soon as 7.1 is released stable.
