### PR TITLE
Fix include from ParsedownTest

### DIFF
--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -139,7 +139,7 @@ EXPECTED_HTML;
 
     public function testLateStaticBinding()
     {
-        include 'test/TestParsedown.php';
+        include __DIR__ . '/TestParsedown.php';
 
         $parsedown = Parsedown::instance();
         $this->assertInstanceOf('Parsedown', $parsedown);


### PR DESCRIPTION
I wasn't able to run all the tests from ParsedownExtra because of it.