### PR TITLE
Trim surrounding whitespace from URL in inlineLink

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1217,7 +1217,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^[(]((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*"|\'[^\']*\'))?[)]/', $remainder, $matches))
+        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*"|\'[^\']*\'))?\s*[)]/', $remainder, $matches))
         {
             $Element['attributes']['href'] = $matches[1];
 


### PR DESCRIPTION
Fixes https://github.com/erusev/parsedown-extra/issues/103