### PR TITLE
Fixed README Caret link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> You might also like [Caret](http://caret.io?ref=parsedown) - our Markdown editor for Mac / Windows / Linux.
+> You might also like [Caret](http://caret.io) - our Markdown editor for Mac / Windows / Linux.
 
 ## Parsedown
 


### PR DESCRIPTION
Might be the site that should be fixed but passing the ?ref tag seems to not allow the site to be visited, removing it worked for me.