### PR TITLE
Prevent various XSS attacks [rebase and update of #276]

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1513,6 +1513,22 @@ class Parsedown
             $Element = $this->filterUnsafeUrlInAttribute($Element, $safeUrlNameToAtt[$Element['name']]);
         }
 
+        if ( ! empty($Element['attributes']))
+        {
+            # clear out nulls
+            $Element['attributes'] = array_filter(
+                $Element['attributes'],
+                function ($v) {return $v !== null;}
+            );
+
+            $onEventAttributes = preg_grep('/^\s*+on/i', array_flip($Element['attributes']));
+
+            foreach ($onEventAttributes as $att)
+            {
+                unset($Element['attributes'][$att]);
+            }
+        }
+
         return $Element;
     }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1533,7 +1533,7 @@ class Parsedown
                     unset($Element['attributes'][$att]);
                 }
                 # dump onevent attribute
-                elseif (preg_match('/^on/i', $att))
+                elseif (self::striAtStart($att, 'on'))
                 {
                     unset($Element['attributes'][$att]);
                 }
@@ -1551,7 +1551,7 @@ class Parsedown
 
             foreach ($this->safeLinksWhitelist as $scheme)
             {
-                if (stripos($Element['attributes'][$attribute], $scheme) === 0)
+                if (self::striAtStart($Element['attributes'][$attribute], $scheme))
                 {
                     $safe = true;
 
@@ -1582,6 +1582,20 @@ class Parsedown
     protected static function escape($text, $allowQuotes = false)
     {
         return htmlspecialchars($text, $allowQuotes ? ENT_NOQUOTES : ENT_QUOTES, 'UTF-8');
+    }
+
+    protected static function striAtStart($string, $needle)
+    {
+        $len = strlen($needle);
+
+        if ($len > strlen($string))
+        {
+            return false;
+        }
+        else
+        {
+            return strtolower(substr($string, 0, $len)) === strtolower($needle);
+        }
     }
 
     static function instance($name = 'default')

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1503,7 +1503,8 @@ class Parsedown
 
     protected function sanitiseElement(array $Element)
     {
-        $safeUrlNameToAtt = array(
+        static $badAttributeChars = "\"'= \t\n\r\0\x0B";
+        static $safeUrlNameToAtt  = array(
             'a'   => 'href',
             'img' => 'src',
         );
@@ -1515,13 +1516,21 @@ class Parsedown
 
         if ( ! empty($Element['attributes']))
         {
-            # clear out nulls
-            $Element['attributes'] = array_filter(
-                $Element['attributes'],
-                function ($v) {return $v !== null;}
-            );
+            foreach ($Element['attributes'] as $att => $val)
+            {
+                # clear out nulls
+                if ($val === null)
+                {
+                    unset($Element['attributes'][$att]);
+                }
+                # filter out badly parsed attribute
+                elseif (strpbrk($att, $badAttributeChars) !== false)
+                {
+                    unset($Element['attributes'][$att]);
+                }
+            }
 
-            $onEventAttributes = preg_grep('/^\s*+on/i', array_flip($Element['attributes']));
+            $onEventAttributes = preg_grep('/^on/i', array_flip($Element['attributes']));
 
             foreach ($onEventAttributes as $att)
             {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1530,9 +1530,9 @@ class Parsedown
                 }
             }
 
-            $onEventAttributes = preg_grep('/^on/i', array_flip($Element['attributes']));
+            $onEventAttributeKeys = preg_grep('/^on/i', array_keys($Element['attributes']));
 
-            foreach ($onEventAttributes as $att)
+            foreach ($onEventAttributeKeys as $att)
             {
                 unset($Element['attributes'][$att]);
             }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1262,13 +1262,18 @@ class Parsedown
             $Element['attributes']['title'] = $Definition['title'];
         }
 
-        if ( $this->safeLinksEnabled && stripos($Element['attributes']['href'], 'javascript:') === 0 )
+        if ( $this->safeLinksEnabled && preg_match("/^(\/|https?:\/\/|ftps?:\/\/)/ui", $Element['attributes']['href']) === 0 )
         {
             return;
         }
 
-        $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href']);
-        $Element['text'] = htmlspecialchars($Element['text']);
+        $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href'], ENT_QUOTES);
+        $Element['text'] = htmlspecialchars($Element['text'], ENT_QUOTES);
+
+        if ( $Element['attributes']['title'] !== null )
+        {
+            $Element['attributes']['title'] = htmlspecialchars($Element['attributes']['title'], ENT_QUOTES);
+        }
 
         return array(
             'extent' => $extent,

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -97,8 +97,6 @@ class Parsedown
         'ircs:',
         'git:',
         'ssh:',
-        'ftp:',
-        'ftps:',
         'news:',
         'steam:',
     );

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -91,7 +91,9 @@ class Parsedown
         'ftp://',
         'ftps://',
         'mailto:',
-        'data:image/png;',
+        'data:image/png;base64,',
+        'data:image/gif;base64,',
+        'data:image/jpg;base64,',
     );
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1554,14 +1554,7 @@ class Parsedown
             }
         }
 
-        $Element['attributes'][$attribute] = preg_replace_callback(
-            '/[^\/#?&=%]++/',
-            function (array $match)
-            {
-                return urlencode($match[0]);
-            },
-            $Element['attributes'][$attribute]
-        );
+        $Element['attributes'][$attribute] = str_replace(':', '%3A', $Element['attributes'][$attribute]);
 
         return $Element;
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1422,7 +1422,10 @@ class Parsedown
 
     protected function element(array $Element)
     {
-        $Element = $this->sanitiseElement($Element);
+        if ($this->safeMode)
+        {
+            $Element = $this->sanitiseElement($Element);
+        }
 
         $markup = '<'.$Element['name'];
 
@@ -1543,26 +1546,22 @@ class Parsedown
 
     protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
     {
-        if ($this->safeMode)
+        foreach ($this->safeLinksWhitelist as $scheme)
         {
-            foreach ($this->safeLinksWhitelist as $scheme)
+            if (self::striAtStart($Element['attributes'][$attribute], $scheme))
             {
-                if (self::striAtStart($Element['attributes'][$attribute], $scheme))
-                {
-                    return $Element;
-                }
+                return $Element;
             }
-
-            $Element['attributes'][$attribute] = preg_replace_callback(
-                '/[^\/#?&=%]++/',
-                function (array $match)
-                {
-                    return urlencode($match[0]);
-                },
-                $Element['attributes'][$attribute]
-            );
-
         }
+
+        $Element['attributes'][$attribute] = preg_replace_callback(
+            '/[^\/#?&=%]++/',
+            function (array $match)
+            {
+                return urlencode($match[0]);
+            },
+            $Element['attributes'][$attribute]
+        );
 
         return $Element;
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -422,7 +422,7 @@ class Parsedown
 
             if (isset($matches[1]))
             {
-                $class = 'language-'.$matches[1];
+                $class = 'language-'.htmlspecialchars($matches[1], ENT_QUOTES, 'UTF-8');
 
                 $Element['attributes'] = array(
                     'class' => $class,
@@ -532,10 +532,10 @@ class Parsedown
                 ),
             );
 
-            if($name === 'ol') 
+            if($name === 'ol')
             {
                 $listStart = stristr($matches[0], '.', true);
-                
+
                 if($listStart !== '1')
                 {
                     $Block['element']['attributes'] = array('start' => $listStart);
@@ -1108,7 +1108,7 @@ class Parsedown
     {
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<((mailto:)?\S+?@\S+?)>/i', $Excerpt['text'], $matches))
         {
-            $url = $matches[1];
+            $url = htmlspecialchars($matches[1], ENT_QUOTES, 'UTF-8');
 
             if ( ! isset($matches[2]))
             {
@@ -1288,12 +1288,12 @@ class Parsedown
             }
         }
 
-        $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href'], ENT_QUOTES);
-        $Element['text'] = htmlspecialchars($Element['text'], ENT_QUOTES);
+        $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href'], ENT_QUOTES, 'UTF-8');
+        $Element['text'] = htmlspecialchars($Element['text'], ENT_QUOTES, 'UTF-8');
 
         if ( $Element['attributes']['title'] !== null )
         {
-            $Element['attributes']['title'] = htmlspecialchars($Element['attributes']['title'], ENT_QUOTES);
+            $Element['attributes']['title'] = htmlspecialchars($Element['attributes']['title'], ENT_QUOTES, 'UTF-8');
         }
 
         return array(
@@ -1384,14 +1384,16 @@ class Parsedown
 
         if (preg_match('/\bhttps?:[\/]{2}[^\s<]+\b\/*/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE))
         {
+            $url = htmlspecialchars($matches[0][0], ENT_QUOTES, 'UTF-8');
+
             $Inline = array(
                 'extent' => strlen($matches[0][0]),
                 'position' => $matches[0][1],
                 'element' => array(
                     'name' => 'a',
-                    'text' => $matches[0][0],
+                    'text' => $url,
                     'attributes' => array(
-                        'href' => $matches[0][0],
+                        'href' => $url,
                     ),
                 ),
             );
@@ -1404,7 +1406,7 @@ class Parsedown
     {
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\w+:\/{2}[^ >]+)>/i', $Excerpt['text'], $matches))
         {
-            $url = str_replace(array('&', '<'), array('&amp;', '&lt;'), $matches[1]);
+            $url = htmlspecialchars($matches[1], ENT_QUOTES, 'UTF-8');
 
             return array(
                 'extent' => strlen($matches[0]),

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -93,6 +93,14 @@ class Parsedown
         'data:image/png;base64,',
         'data:image/gif;base64,',
         'data:image/jpeg;base64,',
+        'irc:',
+        'ircs:',
+        'git:',
+        'ssh:',
+        'ftp:',
+        'ftps:',
+        'news:',
+        'steam:',
     );
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -93,7 +93,7 @@ class Parsedown
         'mailto:',
         'data:image/png;base64,',
         'data:image/gif;base64,',
-        'data:image/jpg;base64,',
+        'data:image/jpeg;base64,',
     );
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -75,6 +75,15 @@ class Parsedown
 
     protected $urlsLinked = true;
 
+    function setSafeLinksEnabled($safeLinksEnabled)
+    {
+        $this->safeLinksEnabled = $safeLinksEnabled;
+
+        return $this;
+    }
+
+    protected $safeLinksEnabled = true;
+
     #
     # Lines
     #
@@ -1253,7 +1262,13 @@ class Parsedown
             $Element['attributes']['title'] = $Definition['title'];
         }
 
-        $Element['attributes']['href'] = str_replace(array('&', '<'), array('&amp;', '&lt;'), $Element['attributes']['href']);
+        if ( $this->safeLinksEnabled && stripos($Element['attributes']['href'], 'javascript:') === 0 )
+        {
+            return;
+        }
+
+        $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href']);
+        $Element['text'] = htmlspecialchars($Element['text']);
 
         return array(
             'extent' => $extent,

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1505,7 +1505,7 @@ class Parsedown
 
     protected function sanitiseElement(array $Element)
     {
-        static $badAttributeChars = "\"'= \t\n\r\0\x0B";
+        static $goodAttribute = '/^[a-zA-Z0-9][a-zA-Z0-9-_]*+$/';
         static $safeUrlNameToAtt  = array(
             'a'   => 'href',
             'img' => 'src',
@@ -1520,23 +1520,16 @@ class Parsedown
         {
             foreach ($Element['attributes'] as $att => $val)
             {
-                # clear out nulls
-                if ($val === null)
-                {
-                    unset($Element['attributes'][$att]);
-                }
                 # filter out badly parsed attribute
-                elseif (strpbrk($att, $badAttributeChars) !== false)
+                if ( ! preg_match($goodAttribute, $att))
                 {
                     unset($Element['attributes'][$att]);
                 }
-            }
-
-            $onEventAttributeKeys = preg_grep('/^on/i', array_keys($Element['attributes']));
-
-            foreach ($onEventAttributeKeys as $att)
-            {
-                unset($Element['attributes'][$att]);
+                # dump onevent attribute
+                elseif (preg_match('/^on/i', $att))
+                {
+                    unset($Element['attributes'][$att]);
+                }
             }
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1547,29 +1547,23 @@ class Parsedown
     {
         if ($this->safeLinksEnabled)
         {
-            $safe = false;
-
             foreach ($this->safeLinksWhitelist as $scheme)
             {
                 if (self::striAtStart($Element['attributes'][$attribute], $scheme))
                 {
-                    $safe = true;
-
-                    break;
+                    return $Element;
                 }
             }
 
-            if ( ! $safe)
-            {
-                $Element['attributes'][$attribute] = preg_replace_callback(
-                    '/[^\/#?&=%]++/',
-                    function (array $match)
-                    {
-                        return urlencode($match[0]);
-                    },
-                    $Element['attributes'][$attribute]
-                );
-            }
+            $Element['attributes'][$attribute] = preg_replace_callback(
+                '/[^\/#?&=%]++/',
+                function (array $match)
+                {
+                    return urlencode($match[0]);
+                },
+                $Element['attributes'][$attribute]
+            );
+
         }
 
         return $Element;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -87,7 +87,6 @@ class Parsedown
     protected $safeLinksWhitelist = array(
         'http://',
         'https://',
-        '/',
         'ftp://',
         'ftps://',
         'mailto:',
@@ -1554,7 +1553,14 @@ class Parsedown
 
             if ( ! $safe)
             {
-                unset($Element['attributes'][$attribute]);
+                $Element['attributes'][$attribute] = preg_replace_callback(
+                    '/[^\/#?&=%]++/',
+                    function (array $match)
+                    {
+                        return urlencode($match[0]);
+                    },
+                    $Element['attributes'][$attribute]
+                );
             }
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -84,6 +84,14 @@ class Parsedown
 
     protected $safeLinksEnabled = true;
 
+    protected $safeLinksWhitelist = array(
+        'http://',
+        'https://',
+        '/',
+        'ftp://',
+        'ftps://'
+    );
+
     #
     # Lines
     #
@@ -1262,9 +1270,22 @@ class Parsedown
             $Element['attributes']['title'] = $Definition['title'];
         }
 
-        if ( $this->safeLinksEnabled && preg_match("/^(\/|https?:\/\/|ftps?:\/\/)/ui", $Element['attributes']['href']) === 0 )
+        if ( $this->safeLinksEnabled )
         {
-            return;
+            $matched = false;
+            foreach ( $this->safeLinksWhitelist as $scheme )
+            {
+                if ( stripos($Element['attributes']['href'], $scheme) === 0 )
+                {
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if ( ! $matched )
+            {
+                return;
+            }
         }
 
         $Element['attributes']['href'] = htmlspecialchars($Element['attributes']['href'], ENT_QUOTES);

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -75,14 +75,14 @@ class Parsedown
 
     protected $urlsLinked = true;
 
-    function setSafeLinksEnabled($safeLinksEnabled)
+    function setSafeMode($safeMode)
     {
-        $this->safeLinksEnabled = $safeLinksEnabled;
+        $this->safeMode = (bool) $safeMode;
 
         return $this;
     }
 
-    protected $safeLinksEnabled = true;
+    protected $safeMode;
 
     protected $safeLinksWhitelist = array(
         'http://',
@@ -378,7 +378,7 @@ class Parsedown
 
     protected function blockComment($Line)
     {
-        if ($this->markupEscaped)
+        if ($this->markupEscaped or $this->safeMode)
         {
             return;
         }
@@ -700,7 +700,7 @@ class Parsedown
 
     protected function blockMarkup($Line)
     {
-        if ($this->markupEscaped)
+        if ($this->markupEscaped or $this->safeMode)
         {
             return;
         }
@@ -1282,7 +1282,7 @@ class Parsedown
 
     protected function inlineMarkup($Excerpt)
     {
-        if ($this->markupEscaped or strpos($Excerpt['text'], '>') === false)
+        if ($this->markupEscaped or $this->safeMode or strpos($Excerpt['text'], '>') === false)
         {
             return;
         }
@@ -1543,7 +1543,7 @@ class Parsedown
 
     protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
     {
-        if ($this->safeLinksEnabled)
+        if ($this->safeMode)
         {
             foreach ($this->safeLinksWhitelist as $scheme)
             {

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -46,7 +46,7 @@ class ParsedownTest extends PHPUnit_Framework_TestCase
         $expectedMarkup = str_replace("\r\n", "\n", $expectedMarkup);
         $expectedMarkup = str_replace("\r", "\n", $expectedMarkup);
 
-        $this->Parsedown->setMarkupEscaped($test === 'xss_text_encoding');
+        $this->Parsedown->setSafeMode(substr($test, 0, 3) === 'xss');
 
         $actualMarkup = $this->Parsedown->text($markdown);
 

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -46,6 +46,8 @@ class ParsedownTest extends PHPUnit_Framework_TestCase
         $expectedMarkup = str_replace("\r\n", "\n", $expectedMarkup);
         $expectedMarkup = str_replace("\r", "\n", $expectedMarkup);
 
+        $this->Parsedown->setMarkupEscaped($test === 'xss_text_encoding');
+
         $actualMarkup = $this->Parsedown->text($markdown);
 
         $this->assertEquals($expectedMarkup, $actualMarkup);

--- a/test/data/inline_link.html
+++ b/test/data/inline_link.html
@@ -1,5 +1,5 @@
 <p><a href="http://example.com">link</a></p>
-<p><a href="/url-%28parentheses%29">link</a> with parentheses in URL </p>
+<p><a href="/url-(parentheses)">link</a> with parentheses in URL </p>
 <p>(<a href="/index.php">link</a>) in parentheses</p>
 <p><a href="http://example.com"><code>link</code></a></p>
 <p><a href="http://example.com"><img src="http://parsedown.org/md.png" alt="MD Logo" /></a></p>

--- a/test/data/inline_link.html
+++ b/test/data/inline_link.html
@@ -1,5 +1,5 @@
 <p><a href="http://example.com">link</a></p>
-<p><a href="/url-(parentheses)">link</a> with parentheses in URL </p>
+<p><a href="/url-%28parentheses%29">link</a> with parentheses in URL </p>
 <p>(<a href="/index.php">link</a>) in parentheses</p>
 <p><a href="http://example.com"><code>link</code></a></p>
 <p><a href="http://example.com"><img src="http://parsedown.org/md.png" alt="MD Logo" /></a></p>

--- a/test/data/xss_attribute_encoding.html
+++ b/test/data/xss_attribute_encoding.html
@@ -1,0 +1,6 @@
+<p><a href="https://www.example.com&quot;">xss</a></p>
+<p><img src="https://www.example.com&quot;" alt="xss" /></p>
+<p><a href="https://www.example.com&#039;">xss</a></p>
+<p><img src="https://www.example.com&#039;" alt="xss" /></p>
+<p><img src="https://www.example.com" alt="xss&quot;" /></p>
+<p><img src="https://www.example.com" alt="xss&#039;" /></p>

--- a/test/data/xss_attribute_encoding.md
+++ b/test/data/xss_attribute_encoding.md
@@ -1,0 +1,11 @@
+[xss](https://www.example.com")
+
+![xss](https://www.example.com")
+
+[xss](https://www.example.com')
+
+![xss](https://www.example.com')
+
+![xss"](https://www.example.com)
+
+![xss'](https://www.example.com)

--- a/test/data/xss_bad_url.html
+++ b/test/data/xss_bad_url.html
@@ -1,0 +1,16 @@
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><a>xss</a></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>
+<p><img alt="xss" /></p>

--- a/test/data/xss_bad_url.html
+++ b/test/data/xss_bad_url.html
@@ -1,16 +1,16 @@
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><a>xss</a></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
-<p><img alt="xss" /></p>
+<p><a href="javascript%3Aalert%281%29">xss</a></p>
+<p><a href="javascript%3Aalert%281%29">xss</a></p>
+<p><a href="javascript%3A//alert%281%29">xss</a></p>
+<p><a href="javascript&amp;colon%3Balert%281%29">xss</a></p>
+<p><img src="javascript%3Aalert%281%29" alt="xss" /></p>
+<p><img src="javascript%3Aalert%281%29" alt="xss" /></p>
+<p><img src="javascript%3A//alert%281%29" alt="xss" /></p>
+<p><img src="javascript&amp;colon%3Balert%281%29" alt="xss" /></p>
+<p><a href="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data%3A//text/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data&amp;colon%3Btext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><img src="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data%3A//text/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data&amp;colon%3Btext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>

--- a/test/data/xss_bad_url.html
+++ b/test/data/xss_bad_url.html
@@ -1,16 +1,16 @@
-<p><a href="javascript%3Aalert%281%29">xss</a></p>
-<p><a href="javascript%3Aalert%281%29">xss</a></p>
-<p><a href="javascript%3A//alert%281%29">xss</a></p>
-<p><a href="javascript&amp;colon%3Balert%281%29">xss</a></p>
-<p><img src="javascript%3Aalert%281%29" alt="xss" /></p>
-<p><img src="javascript%3Aalert%281%29" alt="xss" /></p>
-<p><img src="javascript%3A//alert%281%29" alt="xss" /></p>
-<p><img src="javascript&amp;colon%3Balert%281%29" alt="xss" /></p>
-<p><a href="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
-<p><a href="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
-<p><a href="data%3A//text/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
-<p><a href="data&amp;colon%3Btext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
-<p><img src="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
-<p><img src="data%3Atext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
-<p><img src="data%3A//text/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
-<p><img src="data&amp;colon%3Btext/html%3Bbase64%2CPHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><a href="javascript%3Aalert(1)">xss</a></p>
+<p><a href="javascript%3Aalert(1)">xss</a></p>
+<p><a href="javascript%3A//alert(1)">xss</a></p>
+<p><a href="javascript&amp;colon;alert(1)">xss</a></p>
+<p><img src="javascript%3Aalert(1)" alt="xss" /></p>
+<p><img src="javascript%3Aalert(1)" alt="xss" /></p>
+<p><img src="javascript%3A//alert(1)" alt="xss" /></p>
+<p><img src="javascript&amp;colon;alert(1)" alt="xss" /></p>
+<p><a href="data%3Atext/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data%3Atext/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data%3A//text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><a href="data&amp;colon;text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">xss</a></p>
+<p><img src="data%3Atext/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data%3Atext/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data%3A//text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>
+<p><img src="data&amp;colon;text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" alt="xss" /></p>

--- a/test/data/xss_bad_url.md
+++ b/test/data/xss_bad_url.md
@@ -1,0 +1,31 @@
+[xss](javascript:alert(1))
+
+[xss]( javascript:alert(1))
+
+[xss](javascript://alert(1))
+
+[xss](javascript&colon;alert(1))
+
+![xss](javascript:alert(1))
+
+![xss]( javascript:alert(1))
+
+![xss](javascript://alert(1))
+
+![xss](javascript&colon;alert(1))
+
+[xss](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+[xss]( data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+[xss](data://text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+[xss](data&colon;text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![xss](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![xss]( data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![xss](data://text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)
+
+![xss](data&colon;text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)

--- a/test/data/xss_text_encoding.html
+++ b/test/data/xss_text_encoding.html
@@ -1,0 +1,7 @@
+<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>
+<p>&lt;script&gt;</p>
+<p>alert(1)</p>
+<p>&lt;/script&gt;</p>
+<p>&lt;script&gt;
+alert(1)
+&lt;/script&gt;</p>

--- a/test/data/xss_text_encoding.md
+++ b/test/data/xss_text_encoding.md
@@ -1,0 +1,12 @@
+<script>alert(1)</script>
+
+<script>
+
+alert(1)
+
+</script>
+
+
+<script>
+alert(1)
+</script>


### PR DESCRIPTION
I've picked up on the work started over at https://github.com/erusev/parsedown/pull/276 and rebased on `erusev/master`.

Since this is rebased on master, I can't point at PR at `naNuke/master` without running into the merge conflicts that I've already resolved manually.

I've implemented what I suggested [earlier](https://github.com/erusev/parsedown/pull/276#issuecomment-298244798) so that all attributes are properly encoded (and not just the specific ones we remember).

I've also added some tests, so @erusev's concern here should hopefully now be resolved, albeit a year later 😉 
https://github.com/erusev/parsedown/pull/276#issuecomment-178577968
> @malas one reason is the lack of tests

~~One thing to note is that all this can be circumvented if you forget to turn on `$Parsedown->setMarkupEscaped(true);`
(which is off by default) as you could just write a script tag manually for xss (even though the attributes and link destinations will be safe). So let's all remember to enable this setting 😉~~

Attributes are now always escaped properly (this speaks to just outputting things correctly), but link based XSS or XSS from writing plain old script tags will only be prevented only if the new `setSafeMode` is enabled.

```php
$Parsedown->setSafeMode(true);
```

---

Closes #161
Closes #497
Closes #276
Closes #403 
Closes #530