### PR TITLE
Fix hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
   - nightly
 
 matrix:
+  include:
+    - php: 5.3
+      dist: precise
   fast_finish: true
   allow_failures:
     - php: nightly
 
+dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,22 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - hhvm
   - nightly
-  - hhvm-nightly
 
 matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: hhvm
+      install:
+        - composer require phpunit/phpunit --dev --no-update --no-interaction
+        - travis_retry composer install --prefer-dist --no-interaction --no-suggest
+      script: vendor/bin/phpunit
+    - php: hhvm-nightly
+      install:
+        - composer require phpunit/phpunit --dev --no-update --no-interaction
+        - travis_retry composer install --prefer-dist --no-interaction --no-suggest
+      script: vendor/bin/phpunit
   fast_finish: true
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 5.4
   - hhvm
   - nightly
+  - hhvm-nightly
 
 matrix:
   include:
@@ -16,6 +17,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: nightly
+    - php: hhvm-nightly
 
 dist: trusty
 sudo: false


### PR DESCRIPTION
Fix HHVM (for real this time 😉)

Upon merge, I shall open a bug/PR in this repo to remove the line `dist: trusty`, which should be removed once Travis updates their stable container to trusty.

---

I've also tacked on `hhvm-nightly` as a build stage, since that is supported in trusty (I think?) – which we'll now be using.

cc: @PhrozenByte 