### PR TITLE
Removing mbstring dependency

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -141,7 +141,14 @@ class Parsedown
 
                 foreach ($parts as $part)
                 {
-                    $shortage = 4 - mb_strlen($line, 'utf-8') % 4;
+                    if(function_exists('mb_strlen'))
+                    {
+                        $shortage = 4 - mb_strlen($line, 'utf8') % 4;
+                    }
+                    else
+                    {
+                        $shortage = 4 - strlen($line) % 4;
+                    }
 
                     $line .= str_repeat(' ', $shortage);
                     $line .= $part;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -141,11 +141,11 @@ class Parsedown
 
                 foreach ($parts as $part)
                 {
-                    if(function_exists(mb_strlen))
+                    if(function_exists('mb_strlen'))
                     {
                         $shortage = 4 - mb_strlen($line, 'UTF-8') % 4;
                     }
-                    elseif(function_exists(iconv_strlen))
+                    elseif(function_exists('iconv_strlen'))
                     {
                         $shortage = 4 - iconv_strlen($line, 'UTF-8') % 4;
                     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -147,7 +147,7 @@ class Parsedown
                     }
                     elseif(function_exists('iconv_strlen'))
                     {
-                        $shortage = 4 - iconv_strlen($line, 'UTF-8') % 4;
+                        $shortage = 4 - @iconv_strlen($line, 'UTF-8') % 4;
                     }
                     else
                     {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -141,13 +141,17 @@ class Parsedown
 
                 foreach ($parts as $part)
                 {
-                    if(function_exists('mb_strlen'))
-                    {
-                        $shortage = 4 - mb_strlen($line, 'utf8') % 4;
+                    if(function_exists(mb_strlen))
+                    {   
+                        $shortage = 4 - mb_strlen($line, 'UTF-8') % 4;
+                    }
+                    elseif(function_exists(iconv_strlen))
+                    {   
+                        $shortage = 4 - iconv_strlen($line, 'UTF-8') % 4;
                     }
                     else
                     {
-                        $shortage = 4 - strlen($line) % 4;
+                        $shortage = 4 - preg_match_all("/.{1}/us",$line) % 4;
                     }
 
                     $line .= str_repeat(' ', $shortage);

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -142,11 +142,11 @@ class Parsedown
                 foreach ($parts as $part)
                 {
                     if(function_exists(mb_strlen))
-                    {   
+                    {
                         $shortage = 4 - mb_strlen($line, 'UTF-8') % 4;
                     }
                     elseif(function_exists(iconv_strlen))
-                    {   
+                    {
                         $shortage = 4 - iconv_strlen($line, 'UTF-8') % 4;
                     }
                     else


### PR DESCRIPTION
The dependency to mbstring in php7 could be removed with a fallback to strlen.