### PR TITLE
Add mbstring dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35"


### PR DESCRIPTION
Parsedown requires PHP's `mbstring` extension due to

https://github.com/erusev/parsedown/blob/d638fd8a25ba1a04106a663d80442afe5bc8d8a0/Parsedown.php#L170

Parsedown never worked without the `mbstring` extension and users were experiencing PHP errors. Most PHP installations have `mbstring` enabled (even though it's not one of PHP's default extensions, it's a default extension on virtually any Linux distribution), so IMO there's no need for action here besides making this implicit dependency explicit. Users which can't install `mbstring` on their platform can still use a polyfill like https://github.com/symfony/polyfill-mbstring, but since it's comparibly slow and users should rather install the `mbstring` extension whenever possible, we shouldn't make the polyfill the default. Letting users know about this is IMO the best way to deal with it.

Also see #541 - what should be closed IMO