### PR TITLE
Remove legacy escaping

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1189,7 +1189,7 @@ class Parsedown
         if (isset($Excerpt['text'][1]) and in_array($Excerpt['text'][1], $this->specialCharacters))
         {
             return array(
-                'markup' => $Excerpt['text'][1],
+                'element' => array('rawHtml' => $Excerpt['text'][1]),
                 'extent' => 2,
             );
         }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -964,13 +964,11 @@ class Parsedown
     #
 
     protected $InlineTypes = array(
-        '"' => array('SpecialCharacter'),
         '!' => array('Image'),
         '&' => array('SpecialCharacter'),
         '*' => array('Emphasis'),
         ':' => array('Url'),
-        '<' => array('UrlTag', 'EmailTag', 'Markup', 'SpecialCharacter'),
-        '>' => array('SpecialCharacter'),
+        '<' => array('UrlTag', 'EmailTag', 'Markup'),
         '[' => array('Link'),
         '_' => array('Emphasis'),
         '`' => array('Code'),
@@ -980,7 +978,7 @@ class Parsedown
 
     # ~
 
-    protected $inlineMarkerList = '!"*_&[:<>`~\\';
+    protected $inlineMarkerList = '!*_&[:<`~\\';
 
     #
     # ~
@@ -1337,23 +1335,15 @@ class Parsedown
 
     protected function inlineSpecialCharacter($Excerpt)
     {
-        if ($Excerpt['text'][0] === '&' and ! preg_match('/^&#?\w+;/', $Excerpt['text']))
+        if (preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches))
         {
             return array(
-                'markup' => '&amp;',
-                'extent' => 1,
+                'element' => array('rawHtml' => '&'.$matches[1].';'),
+                'extent' => strlen($matches[0]),
             );
         }
 
-        $SpecialCharacter = array('>' => 'gt', '<' => 'lt', '"' => 'quot');
-
-        if (isset($SpecialCharacter[$Excerpt['text'][0]]))
-        {
-            return array(
-                'markup' => '&'.$SpecialCharacter[$Excerpt['text'][0]].';',
-                'extent' => 1,
-            );
-        }
+        return;
     }
 
     protected function inlineStrikethrough($Excerpt)

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -386,7 +386,7 @@ class Parsedown
         if (isset($Line['text'][3]) and $Line['text'][3] === '-' and $Line['text'][2] === '-' and $Line['text'][1] === '!')
         {
             $Block = array(
-                'markup' => $Line['body'],
+                'element' => array('rawHtml' => $Line['body']),
             );
 
             if (preg_match('/-->$/', $Line['text']))
@@ -405,7 +405,7 @@ class Parsedown
             return;
         }
 
-        $Block['markup'] .= "\n" . $Line['body'];
+        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
 
         if (preg_match('/-->$/', $Line['text']))
         {
@@ -734,7 +734,7 @@ class Parsedown
 
             $Block = array(
                 'name' => $matches[1],
-                'markup' => $Line['text'],
+                'element' => array('rawHtml' => $Line['text']),
             );
 
             return $Block;
@@ -748,7 +748,7 @@ class Parsedown
             return;
         }
 
-        $Block['markup'] .= "\n".$Line['body'];
+        $Block['element']['rawHtml'] .= "\n".$Line['body'];
 
         return $Block;
     }
@@ -1311,7 +1311,7 @@ class Parsedown
         if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*[ ]*>/s', $Excerpt['text'], $matches))
         {
             return array(
-                'markup' => $matches[0],
+                'element' => array('rawHtml' => $matches[0]),
                 'extent' => strlen($matches[0]),
             );
         }
@@ -1319,7 +1319,7 @@ class Parsedown
         if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?[^-])*-->/s', $Excerpt['text'], $matches))
         {
             return array(
-                'markup' => $matches[0],
+                'element' => array('rawHtml' => $matches[0]),
                 'extent' => strlen($matches[0]),
             );
         }
@@ -1327,7 +1327,7 @@ class Parsedown
         if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w[\w-]*(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*\/?>/s', $Excerpt['text'], $matches))
         {
             return array(
-                'markup' => $matches[0],
+                'element' => array('rawHtml' => $matches[0]),
                 'extent' => strlen($matches[0]),
             );
         }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1070,6 +1070,41 @@ class Parsedown
     # ~
     #
 
+    protected function inlineText($text)
+    {
+        $Inline = array(
+            'extent' => strlen($text),
+            'element' => array(
+                'handler' => 'elements',
+            ),
+        );
+
+        if ($this->breaksEnabled)
+        {
+            $Inline['element']['text'] = self::pregReplaceElements(
+                '/[ ]*\n/',
+                array(
+                    array('name' => 'br'),
+                    array('text' => "\n"),
+                ),
+                $text
+            );
+        }
+        else
+        {
+            $Inline['element']['text'] = self::pregReplaceElements(
+                '/(?:[ ][ ]+|[ ]*\\\\)\n/',
+                array(
+                    array('name' => 'br'),
+                    array('text' => "\n"),
+                ),
+                $text
+            );
+        }
+
+        return $Inline;
+    }
+
     protected function inlineCode($Excerpt)
     {
         $marker = $Excerpt['text'][0];
@@ -1391,17 +1426,7 @@ class Parsedown
 
     protected function unmarkedText($text)
     {
-        if ($this->breaksEnabled)
-        {
-            $text = preg_replace('/[ ]*\n/', "<br />\n", $text);
-        }
-        else
-        {
-            $text = preg_replace('/(?:[ ][ ]+|[ ]*\\\\)\n/', "<br />\n", $text);
-            $text = str_replace(" \n", "\n", $text);
-        }
-
-        return $text;
+        return $this->element($this->inlineText($text)['element']);
     }
 
     #
@@ -1524,6 +1549,39 @@ class Parsedown
         }
 
         return $markup;
+    }
+
+    #
+    # AST Convenience
+    #
+
+    /**
+     * Replace occurrences $regexp with $Elements in $text. Return an array of
+     * elements representing the replacement.
+     */
+    protected static function pregReplaceElements($regexp, $Elements, $text)
+    {
+        $newElements = array();
+
+        while (preg_match($regexp, $text, $matches, PREG_OFFSET_CAPTURE))
+        {
+            $offset = $matches[0][1];
+            $before = substr($text, 0, $offset);
+            $after = substr($text, $offset + strlen($matches[0][0]));
+
+            $newElements[] = array('text' => $before);
+
+            foreach ($Elements as $Element)
+            {
+                $newElements[] = $Element;
+            }
+
+            $text = $after;
+        }
+
+        $newElements[] = array('text' => $text);
+
+        return $newElements;
     }
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1489,12 +1489,18 @@ class Parsedown
     {
         $markup = '';
 
+        $autoBreak = true;
+
         foreach ($Elements as $Element)
         {
-            $markup .= "\n" . $this->element($Element);
+            // (autobreak === false) covers both sides of an element
+            $autoBreak = !$autoBreak ? $autoBreak : isset($Element['name']);
+
+            $markup .= ($autoBreak ? "\n" : '') . $this->element($Element);
+            $autoBreak = isset($Element['name']);
         }
 
-        $markup .= "\n";
+        $markup .= $autoBreak ? "\n" : '';
 
         return $markup;
     }
@@ -1538,6 +1544,12 @@ class Parsedown
             'a'   => 'href',
             'img' => 'src',
         );
+
+        if ( ! isset($Element['name']))
+        {
+            unset($Element['attributes']);
+            return $Element;
+        }
 
         if (isset($safeUrlNameToAtt[$Element['name']]))
         {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1416,7 +1416,8 @@ class Parsedown
 
     protected function unmarkedText($text)
     {
-        return $this->element($this->inlineText($text)['element']);
+        $Inline = $this->inlineText($text);
+        return $this->element($Inline['element']);
     }
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -294,7 +294,7 @@ class Parsedown
             }
 
             $markup .= "\n";
-            $markup .= isset($Block['markup']) ? $Block['markup'] : $this->element($Block['element']);
+            $markup .= $this->element($Block['element']);
         }
 
         $markup .= "\n";
@@ -1042,7 +1042,7 @@ class Parsedown
                 $markup .= $this->unmarkedText($unmarkedText);
 
                 # compile the inline
-                $markup .= isset($Inline['markup']) ? $Inline['markup'] : $this->element($Inline['element']);
+                $markup .= $this->element($Inline['element']);
 
                 # remove the examined text
                 $text = substr($text, $Inline['position'] + $Inline['extent']);

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -159,12 +159,12 @@ MARKDOWN_WITH_MARKUP;
 <p>&lt;div&gt;<em>content</em>&lt;/div&gt;</p>
 <p>sparse:</p>
 <p>&lt;div&gt;
-&lt;div class=&quot;inner&quot;&gt;
+&lt;div class="inner"&gt;
 <em>content</em>
 &lt;/div&gt;
 &lt;/div&gt;</p>
 <p>paragraph</p>
-<p>&lt;style type=&quot;text/css&quot;&gt;
+<p>&lt;style type="text/css"&gt;
 p {
 color: red;
 }


### PR DESCRIPTION
This uses the newly added conditionally escaped HTML from #569 in combination with text-element adjacency from #511 to remove some special cased exceptions for HTML to circumvent the AST. In doing so we can get rid of the last of the old ways of escaping things.

Before merge I'm going to apply similar tests to those I did in #495 (i.e. a combination of manual testing and seeing if OWASP Zap can find any XSS with safe mode enabled).

cc: @PhrozenByte for review :)

---

Fixes #573