### PR TITLE
Fix setext heading space handling

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -705,8 +705,10 @@ class Parsedown
             return;
         }
 
-        if (chop($Line['text'], $Line['text'][0]) === '')
-        {
+        if (
+            chop(chop($Line['text'], ' '), $Line['text'][0]) === ''
+            and $Line['indent'] < 4
+        ) {
             $Block['element']['name'] = $Line['text'][0] === '=' ? 'h1' : 'h2';
 
             return $Block;

--- a/test/data/setext_header_spaces.html
+++ b/test/data/setext_header_spaces.html
@@ -1,0 +1,12 @@
+<h1>trailing space</h1>
+<h2>trailing space</h2>
+<h1>leading and trailing space</h1>
+<h2>leading and trailing space</h2>
+<h1>1 leading space</h1>
+<h2>1 leading space</h2>
+<h1>3 leading spaces</h1>
+<h2>3 leading spaces</h2>
+<p>too many leading spaces
+==</p>
+<p>too many leading spaces
+--</p>

--- a/test/data/setext_header_spaces.md
+++ b/test/data/setext_header_spaces.md
@@ -1,0 +1,29 @@
+trailing space
+== 
+
+trailing space
+-- 
+
+leading and trailing space
+ == 
+
+leading and trailing space
+ -- 
+
+1 leading space
+ ==
+
+1 leading space
+ --
+
+3 leading spaces
+   ==
+
+3 leading spaces
+   --
+
+too many leading spaces
+    ==
+
+too many leading spaces
+    --


### PR DESCRIPTION
Setext headings would fail to render if there were trailing spaces, and would fail to fail when too many leading spaces were present.

---

Fixes #571