### PR TITLE
Add .gitignore for repo specific paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Ignore all tests for archive
 /test               export-ignore
 /.gitattributes     export-ignore
+/.gitignore         export-ignore
 /.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/


### PR DESCRIPTION
Since we don't intend to ever commit the file `composer.lock`, nor files in `vendor/` – git should ignore these paths.