### PR TITLE
Fix ordered list interrupt

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -523,7 +523,7 @@ class Parsedown
     #
     # List
 
-    protected function blockList($Line)
+    protected function blockList($Line, array $CurrentBlock = null)
     {
         list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]{1,9}[.\)]');
 
@@ -556,12 +556,20 @@ class Parsedown
                 ),
             );
 
-            if($name === 'ol')
+            if ($name === 'ol')
             {
                 $listStart = ltrim(strstr($matches[1], $Block['data']['markerType'], true), '0') ?: '0';
 
-                if($listStart !== '1')
+                if ($listStart !== '1')
                 {
+                    if (
+                        isset($CurrentBlock)
+                        and ! isset($CurrentBlock['type'])
+                        and ! isset($CurrentBlock['interrupted'])
+                    ) {
+                        return;
+                    }
+
                     $Block['element']['attributes'] = array('start' => $listStart);
                 }
             }

--- a/test/data/ordered_list.html
+++ b/test/data/ordered_list.html
@@ -11,3 +11,6 @@
 <ol start="123">
 <li>one</li>
 </ol>
+<p>foo 1. the following should not start a list
+100.<br />
+200. </p>

--- a/test/data/ordered_list.md
+++ b/test/data/ordered_list.md
@@ -9,3 +9,7 @@ repeating numbers:
 large numbers:
 
 123. one
+
+foo 1. the following should not start a list
+100.  
+200. 


### PR DESCRIPTION
Ordered lists that did not start with `1.` would previously interrupt paragraphs. This goes against CommonMark.

Fixes #454.