### PR TITLE
Decouple manipulating final AST from `text` method

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -36,7 +36,13 @@ class Parsedown
         $lines = explode("\n", $text);
 
         # iterate through lines to identify blocks
-        $markup = $this->lines($lines);
+        $Elements = $this->linesElements($lines);
+
+        # process elements
+        $Elements = $this->process($Elements);
+
+        # convert to markup
+        $markup = $this->elements($Elements);
 
         # trim line breaks
         $markup = trim($markup, "\n");
@@ -1707,6 +1713,11 @@ class Parsedown
         $markup .= $autoBreak ? "\n" : '';
 
         return $markup;
+    }
+
+    protected function process(array $Elements)
+    {
+        return $Elements;
     }
 
     # ~


### PR DESCRIPTION
Add `process` method so extensions may process final AST without copying implementation of `text`.

`process` is currently the identity map. Extensions can override this to whatever they like without worrying about reimplementing `text`.