### PR TITLE
Apply depth first

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1610,8 +1610,6 @@ class Parsedown
 
     protected function elementApplyRecursive($closure, array $Element)
     {
-        $Element = call_user_func($closure, $Element);
-
         if (isset($Element['elements']))
         {
             $Element['elements'] = $this->elementsApplyRecursive($closure, $Element['elements']);
@@ -1620,6 +1618,8 @@ class Parsedown
         {
             $Element['element'] = $this->elementApplyRecursive($closure, $Element['element']);
         }
+
+        $Element = call_user_func($closure, $Element);
 
         return $Element;
     }


### PR DESCRIPTION
Apply depth first to avoid risk of segfault if closure creates subelements