### PR TITLE
Ensure autobreak false is honoured over empty name

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1728,8 +1728,8 @@ class Parsedown
 
         foreach ($Elements as $Element)
         {
-            $autoBreakNext = (isset($Element['name'])
-                || isset($Element['autobreak']) && $Element['autobreak']
+            $autoBreakNext = (isset($Element['autobreak']) && $Element['autobreak']
+                || ! isset($Element['autobreak']) && isset($Element['name'])
             );
             // (autobreak === false) covers both sides of an element
             $autoBreak = !$autoBreak ? $autoBreak : $autoBreakNext;


### PR DESCRIPTION
If explicitly set, ensure autobreak `false` is honoured over empty name check