### PR TITLE
Replace fix in "Explicitly capture $this for PHP 5.3"

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1648,14 +1648,14 @@ class Parsedown
 
     protected function elementsApplyRecursive($closure, array $Elements)
     {
-        return array_reduce(
-            $Elements,
-            function (array $Elements, array $Element) use ($closure) {
-                $Elements[] = $this->elementApplyRecursive($closure, $Element);
-                return $Elements;
-            },
-            array()
-        );
+        $newElements = array();
+
+        foreach ($Elements as $Element)
+        {
+            $newElements[] = $this->elementApplyRecursive($closure, $Element);
+        }
+
+        return $newElements;
     }
 
     protected function element(array $Element)

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1648,13 +1648,10 @@ class Parsedown
 
     protected function elementsApplyRecursive($closure, array $Elements)
     {
-        # PHP 5.3 compat
-        $instance = $this;
-
         return array_reduce(
             $Elements,
-            function (array $Elements, array $Element) use ($instance, $closure) {
-                $Elements[] = $instance->elementApplyRecursive($closure, $Element);
+            function (array $Elements, array $Element) use ($closure) {
+                $Elements[] = $this->elementApplyRecursive($closure, $Element);
                 return $Elements;
             },
             array()


### PR DESCRIPTION
Reverts erusev/parsedown#605

This isn't sufficient because PHP 5.3 doesn't support closure binding