### PR TITLE
Add seperate depth-first function instead of replacing recursive method

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1664,26 +1664,22 @@ class Parsedown
 
     protected function elementsApplyRecursive($closure, array $Elements)
     {
-        $newElements = array();
-
-        foreach ($Elements as $Element)
+        foreach ($Elements as &$Element)
         {
-            $newElements[] = $this->elementApplyRecursive($closure, $Element);
+            $Element = $this->elementApplyRecursive($closure, $Element);
         }
 
-        return $newElements;
+        return $Elements;
     }
 
     protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
     {
-        $newElements = array();
-
-        foreach ($Elements as $Element)
+        foreach ($Elements as &$Element)
         {
-            $newElements[] = $this->elementApplyRecursiveDepthFirst($closure, $Element);
+            $Element = $this->elementApplyRecursiveDepthFirst($closure, $Element);
         }
 
-        return $newElements;
+        return $Elements;
     }
 
     protected function element(array $Element)

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1632,6 +1632,22 @@ class Parsedown
 
     protected function elementApplyRecursive($closure, array $Element)
     {
+        $Element = call_user_func($closure, $Element);
+
+        if (isset($Element['elements']))
+        {
+            $Element['elements'] = $this->elementsApplyRecursive($closure, $Element['elements']);
+        }
+        elseif (isset($Element['element']))
+        {
+            $Element['element'] = $this->elementApplyRecursive($closure, $Element['element']);
+        }
+
+        return $Element;
+    }
+
+    protected function elementApplyRecursiveDepthFirst($closure, array $Element)
+    {
         if (isset($Element['elements']))
         {
             $Element['elements'] = $this->elementsApplyRecursive($closure, $Element['elements']);
@@ -1653,6 +1669,18 @@ class Parsedown
         foreach ($Elements as $Element)
         {
             $newElements[] = $this->elementApplyRecursive($closure, $Element);
+        }
+
+        return $newElements;
+    }
+
+    protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
+    {
+        $newElements = array();
+
+        foreach ($Elements as $Element)
+        {
+            $newElements[] = $this->elementApplyRecursiveDepthFirst($closure, $Element);
         }
 
         return $newElements;


### PR DESCRIPTION
Depth first is useful to have for cases where it can be used, but sometimes we'll need shallow first (e.g. if applying handler recursively).

(Replaces #603)