### PR TITLE
Paragraph block semantics

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -174,6 +174,7 @@ class Parsedown
 
     protected function linesElements(array $lines)
     {
+        $Elements = array();
         $CurrentBlock = null;
 
         foreach ($lines as $line)
@@ -278,7 +279,10 @@ class Parsedown
 
                     if ( ! isset($Block['identified']))
                     {
-                        $Blocks []= $CurrentBlock;
+                        if (isset($CurrentBlock))
+                        {
+                            $Elements[] = $CurrentBlock['element'];
+                        }
 
                         $Block['identified'] = true;
                     }
@@ -306,7 +310,10 @@ class Parsedown
             }
             else
             {
-                $Blocks []= $CurrentBlock;
+                if (isset($CurrentBlock))
+                {
+                    $Elements[] = $CurrentBlock['element'];
+                }
 
                 $CurrentBlock = $this->paragraph($Line);
 
@@ -323,22 +330,9 @@ class Parsedown
 
         # ~
 
-        $Blocks []= $CurrentBlock;
-
-        unset($Blocks[0]);
-
-        # ~
-
-        $Elements = array();
-
-        foreach ($Blocks as $Block)
+        if (isset($CurrentBlock))
         {
-            if (isset($Block['hidden']))
-            {
-                continue;
-            }
-
-            $Elements[] = $Block['element'];
+            $Elements[] = $CurrentBlock['element'];
         }
 
         # ~

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -878,18 +878,13 @@ class Parsedown
 
             $Data = array(
                 'url' => $matches[2],
-                'title' => null,
+                'title' => isset($matches[3]) ? $matches[3] : null,
             );
-
-            if (isset($matches[3]))
-            {
-                $Data['title'] = $matches[3];
-            }
 
             $this->DefinitionData['Reference'][$id] = $Data;
 
             $Block = array(
-                'hidden' => true,
+                'element' => array(),
             );
 
             return $Block;
@@ -1776,6 +1771,11 @@ class Parsedown
 
         foreach ($Elements as $Element)
         {
+            if (empty($Element))
+            {
+                continue;
+            }
+
             $autoBreakNext = (isset($Element['autobreak']) && $Element['autobreak']
                 || ! isset($Element['autobreak']) && isset($Element['name'])
             );

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -65,15 +65,6 @@ class Parsedown
 
     protected $breaksEnabled;
 
-    function setLiteralBreaks($literalBreaks)
-    {
-        $this->literalBreaks = $literalBreaks;
-
-        return $this;
-    }
-
-    protected $literalBreaks;
-
     function setMarkupEscaped($markupEscaped)
     {
         $this->markupEscaped = $markupEscaped;
@@ -179,7 +170,7 @@ class Parsedown
 
         foreach ($lines as $line)
         {
-            if ( ! $this->literalBreaks and chop($line) === '')
+            if (chop($line) === '')
             {
                 if (isset($CurrentBlock))
                 {
@@ -244,15 +235,7 @@ class Parsedown
 
             # ~
 
-            if (isset($text[0]))
-            {
-                $marker = $text[0];
-            }
-            elseif ($this->literalBreaks)
-            {
-                $marker = '\n';
-                $text = '  ';
-            }
+            $marker = $text[0];
 
             # ~
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -283,12 +283,14 @@ class Parsedown
 
             # ~
 
-            if (
-                isset($CurrentBlock)
-                and $CurrentBlock['type'] === 'Paragraph'
-                and ! isset($CurrentBlock['interrupted'])
-            ) {
-                $CurrentBlock['element']['handler']['argument'] .= "\n".$text;
+            if (isset($CurrentBlock) and $CurrentBlock['type'] === 'Paragraph')
+            {
+                $Block = $this->paragraphContinue($Line, $CurrentBlock);
+            }
+
+            if (isset($Block))
+            {
+                $CurrentBlock = $Block;
             }
             else
             {
@@ -1063,6 +1065,18 @@ class Parsedown
                 ),
             ),
         );
+    }
+
+    protected function paragraphContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        $Block['element']['handler']['argument'] .= "\n".$Line['text'];
+
+        return $Block;
     }
 
     #

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -302,8 +302,7 @@ class Parsedown
 
             if (
                 isset($CurrentBlock)
-                and isset($CurrentBlock['element']['name'])
-                and $CurrentBlock['element']['name'] === 'p'
+                and $CurrentBlock['type'] === 'Paragraph'
                 and ! isset($CurrentBlock['interrupted'])
             ) {
                 $CurrentBlock['element']['handler']['argument'] .= "\n".$text;
@@ -355,7 +354,7 @@ class Parsedown
 
     protected function blockCode($Line, $Block = null)
     {
-        if (isset($Block) and ! isset($Block['type']) and ! isset($Block['interrupted']))
+        if (isset($Block) and $Block['type'] === 'Paragraph' and ! isset($Block['interrupted']))
         {
             return;
         }
@@ -610,7 +609,7 @@ class Parsedown
                 {
                     if (
                         isset($CurrentBlock)
-                        and ! isset($CurrentBlock['type'])
+                        and $CurrentBlock['type'] === 'Paragraph'
                         and ! isset($CurrentBlock['interrupted'])
                     ) {
                         return;
@@ -803,7 +802,7 @@ class Parsedown
 
     protected function blockSetextHeader($Line, array $Block = null)
     {
-        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        if ( ! isset($Block) or $Block['type'] !== 'Paragraph' or isset($Block['interrupted']))
         {
             return;
         }
@@ -890,7 +889,7 @@ class Parsedown
 
     protected function blockTable($Line, array $Block = null)
     {
-        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        if ( ! isset($Block) or $Block['type'] !== 'Paragraph' or isset($Block['interrupted']))
         {
             return;
         }
@@ -1070,18 +1069,17 @@ class Parsedown
 
     protected function paragraph($Line)
     {
-        $Block = array(
+        return array(
+            'type' => 'Paragraph',
             'element' => array(
                 'name' => 'p',
                 'handler' => array(
                     'function' => 'lineElements',
                     'argument' => $Line['text'],
                     'destination' => 'elements',
-                )
+                ),
             ),
         );
-
-        return $Block;
     }
 
     #

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -52,7 +52,6 @@ class ParsedownTest extends TestCase
 
         $this->Parsedown->setSafeMode(substr($test, 0, 3) === 'xss');
         $this->Parsedown->setStrictMode(substr($test, 0, 6) === 'strict');
-        $this->Parsedown->setLiteralBreaks(substr($test, 0, 14) === 'literal_breaks');
 
         $actualMarkup = $this->Parsedown->text($markdown);
 

--- a/test/data/literal_breaks.html
+++ b/test/data/literal_breaks.html
@@ -1,6 +1,0 @@
-<p>first line
-<br />
-<br />
-<br />
-<br />
-sixth line</p>

--- a/test/data/literal_breaks.md
+++ b/test/data/literal_breaks.md
@@ -1,6 +1,0 @@
-first line
-
-
-
-
-sixth line


### PR DESCRIPTION
Allow paragraph continuation behaviour to be modified with extensions.

This PR also removes the `setLiteralBreaks` feature that was due to be added in 1.8.0 since this can now easily be implemented in an extension with a combination of this PR and by using interrupt counts (as added in #610 as a fix).