### PR TITLE
General and performance tweaks

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1105,7 +1105,7 @@ class Parsedown
     # ~
     #
 
-    public function line($text, $nonNestables=array())
+    public function line($text, $nonNestables = array())
     {
         return $this->elements($this->lineElements($text, $nonNestables));
     }
@@ -1156,9 +1156,9 @@ class Parsedown
 
                 # cause the new element to 'inherit' our non nestables
 
-                foreach ($nonNestables as $non_nestable)
+                foreach ($nonNestables as $nonNestable)
                 {
-                    $Inline['element']['nonNestables'][] = $non_nestable;
+                    $Inline['element']['nonNestables'][] = $nonNestable;
                 }
 
                 # the text that comes before the inline
@@ -1192,8 +1192,10 @@ class Parsedown
 
         foreach ($Elements as &$Element)
         {
-            $Element['autobreak'] = isset($Element['autobreak'])
-                ? $Element['autobreak'] : false;
+            if ( ! isset($Element['autobreak']))
+            {
+                $Element['autobreak'] = false;
+            }
         }
 
         return $Elements;
@@ -1763,8 +1765,8 @@ class Parsedown
                 continue;
             }
 
-            $autoBreakNext = (isset($Element['autobreak']) && $Element['autobreak']
-                || ! isset($Element['autobreak']) && isset($Element['name'])
+            $autoBreakNext = (isset($Element['autobreak'])
+                ? $Element['autobreak'] : isset($Element['name'])
             );
             // (autobreak === false) covers both sides of an element
             $autoBreak = !$autoBreak ? $autoBreak : $autoBreakNext;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -442,7 +442,7 @@ class Parsedown
 
     protected function blockFencedCode($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].']{3,})[ ]*([^`]+)?[ ]*$/', $Line['text'], $matches))
+        if (preg_match('/^(['.$Line['text'][0].']{3,}+)[ ]*+([^`]++)?+[ ]*+$/', $Line['text'], $matches))
         {
             $Element = array(
                 'name' => 'code',
@@ -486,7 +486,7 @@ class Parsedown
         }
 
         if (
-            preg_match('/^(['.preg_quote($Block['char']).']{3,})[ ]*$/', $Line['text'], $matches)
+            preg_match('/^(['.preg_quote($Block['char']).']{3,}+)[ ]*+$/', $Line['text'], $matches)
             and mb_strlen($matches[1]) >= $Block['openerLength']
         ) {
             $Block['element']['element']['text'] = substr($Block['element']['element']['text'], 1);
@@ -555,9 +555,9 @@ class Parsedown
 
     protected function blockList($Line, array $CurrentBlock = null)
     {
-        list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]{1,9}[.\)]');
+        list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]{1,9}+[.\)]');
 
-        if (preg_match('/^('.$pattern.'([ ]+|$))(.*)/', $Line['text'], $matches))
+        if (preg_match('/^('.$pattern.'([ ]++|$))(.*+)/', $Line['text'], $matches))
         {
             $contentIndent = strlen($matches[2]);
 
@@ -587,6 +587,7 @@ class Parsedown
                     'elements' => array(),
                 ),
             );
+            $Block['data']['markerTypeRegex'] = preg_quote($Block['data']['markerType'], '/');
 
             if ($name === 'ol')
             {
@@ -634,10 +635,10 @@ class Parsedown
             and (
                 (
                     $Block['data']['type'] === 'ol'
-                    and preg_match('/^[0-9]+'.preg_quote($Block['data']['markerType']).'(?:[ ]+(.*)|$)/', $Line['text'], $matches)
+                    and preg_match('/^[0-9]++'.$Block['data']['markerTypeRegex'].'(?:[ ]++(.*)|$)/', $Line['text'], $matches)
                 ) or (
                     $Block['data']['type'] === 'ul'
-                    and preg_match('/^'.preg_quote($Block['data']['markerType']).'(?:[ ]+(.*)|$)/', $Line['text'], $matches)
+                    and preg_match('/^'.$Block['data']['markerTypeRegex'].'(?:[ ]++(.*)|$)/', $Line['text'], $matches)
                 )
             )
         ) {
@@ -699,7 +700,7 @@ class Parsedown
 
         if ( ! isset($Block['interrupted']))
         {
-            $text = preg_replace('/^[ ]{0,'.$requiredIndent.'}/', '', $Line['body']);
+            $text = preg_replace('/^[ ]{0,'.$requiredIndent.'}+/', '', $Line['body']);
 
             $Block['li']['handler']['argument'] []= $text;
 
@@ -728,7 +729,7 @@ class Parsedown
 
     protected function blockQuote($Line)
     {
-        if (preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
         {
             $Block = array(
                 'element' => array(
@@ -752,7 +753,7 @@ class Parsedown
             return;
         }
 
-        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?(.*)/', $Line['text'], $matches))
+        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
         {
             $Block['element']['handler']['argument'] []= $matches[1];
 
@@ -772,7 +773,7 @@ class Parsedown
 
     protected function blockRule($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].'])([ ]*\1){2,}[ ]*$/', $Line['text']))
+        if (preg_match('/^(['.$Line['text'][0].'])([ ]*+\1){2,}+[ ]*+$/', $Line['text']))
         {
             $Block = array(
                 'element' => array(
@@ -814,7 +815,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^<[\/]?+(\w*)(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*(\/)?>/', $Line['text'], $matches))
+        if (preg_match('/^<[\/]?+(\w*)(?:[ ]*+'.$this->regexHtmlAttribute.')*+[ ]*+(\/)?>/', $Line['text'], $matches))
         {
             $element = strtolower($matches[1]);
 
@@ -852,7 +853,7 @@ class Parsedown
 
     protected function blockReference($Line)
     {
-        if (preg_match('/^\[(.+?)\]:[ ]*<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*$/', $Line['text'], $matches))
+        if (preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches))
         {
             $id = strtolower($matches[1]);
 
@@ -1013,7 +1014,7 @@ class Parsedown
             $row = trim($row);
             $row = trim($row, '|');
 
-            preg_match_all('/(?:(\\\\[|])|[^|`]|`[^`]+`|`)+/', $row, $matches);
+            preg_match_all('/(?:(\\\\[|])|[^|`]|`[^`]++`|`)++/', $row, $matches);
 
             $cells = array_slice($matches[0], 0, count($Block['alignments']));
 
@@ -1236,10 +1237,10 @@ class Parsedown
     {
         $marker = $Excerpt['text'][0];
 
-        if (preg_match('/^('.$marker.'+)[ ]*(.+?)[ ]*(?<!'.$marker.')\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
+        if (preg_match('/^(['.$marker.']++)[ ]*+(.+?)[ ]*+(?<!['.$marker.'])\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
         {
             $text = $matches[2];
-            $text = preg_replace("/[ ]*\n/", ' ', $text);
+            $text = preg_replace('/[ ]*+\n/', ' ', $text);
 
             return array(
                 'extent' => strlen($matches[0]),
@@ -1395,7 +1396,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*"|\'[^\']*\'))?\s*[)]/', $remainder, $matches))
+        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
         {
             $Element['attributes']['href'] = $matches[1];
 
@@ -1444,7 +1445,7 @@ class Parsedown
             return;
         }
 
-        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*[ ]*>/s', $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
         {
             return array(
                 'element' => array('rawHtml' => $matches[0]),
@@ -1452,7 +1453,7 @@ class Parsedown
             );
         }
 
-        if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?[^-])*-->/s', $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?+[^-])*-->/s', $Excerpt['text'], $matches))
         {
             return array(
                 'element' => array('rawHtml' => $matches[0]),
@@ -1460,7 +1461,7 @@ class Parsedown
             );
         }
 
-        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w[\w-]*(?:[ ]*'.$this->regexHtmlAttribute.')*[ ]*\/?>/s', $Excerpt['text'], $matches))
+        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w[\w-]*+(?:[ ]*+'.$this->regexHtmlAttribute.')*+[ ]*+\/?>/s', $Excerpt['text'], $matches))
         {
             return array(
                 'element' => array('rawHtml' => $matches[0]),
@@ -1512,7 +1513,7 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/\bhttps?:[\/]{2}[^\s<]+\b\/*/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE))
+        if (preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE))
         {
             $url = $matches[0][0];
 
@@ -1534,7 +1535,7 @@ class Parsedown
 
     protected function inlineUrlTag($Excerpt)
     {
-        if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\w+:\/{2}[^ >]+)>/i', $Excerpt['text'], $matches))
+        if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\w++:\/{2}[^ >]++)>/i', $Excerpt['text'], $matches))
         {
             $url = $matches[1];
 
@@ -1939,8 +1940,8 @@ class Parsedown
     );
 
     protected $StrongRegex = array(
-        '*' => '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*[*])+?)[*]{2}(?![*])/s',
-        '_' => '/^__((?:\\\\_|[^_]|_[^_]*_)+?)__(?!_)/us',
+        '*' => '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*+[*])+?)[*]{2}(?![*])/s',
+        '_' => '/^__((?:\\\\_|[^_]|_[^_]*+_)+?)__(?!_)/us',
     );
 
     protected $EmRegex = array(
@@ -1948,7 +1949,7 @@ class Parsedown
         '_' => '/^_((?:\\\\_|[^_]|__[^_]*__)+?)_(?!_)\b/us',
     );
 
-    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*(?:\s*=\s*(?:[^"\'=<>`\s]+|"[^"]*"|\'[^\']*\'))?';
+    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
 
     protected $voidElements = array(
         'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source',

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -216,7 +216,7 @@ class Parsedown
 
             if (isset($CurrentBlock['continuable']))
             {
-                $Block = $this->{'block'.$CurrentBlock['type'].'Continue'}($Line, $CurrentBlock);
+                $Block = $this->{"block{$CurrentBlock['type']}Continue"}($Line, $CurrentBlock);
 
                 if (isset($Block))
                 {
@@ -228,7 +228,7 @@ class Parsedown
                 {
                     if ($this->isBlockCompletable($CurrentBlock['type']))
                     {
-                        $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+                        $CurrentBlock = $this->{"block{$CurrentBlock['type']}Complete"}($CurrentBlock);
                     }
                 }
             }
@@ -254,7 +254,7 @@ class Parsedown
 
             foreach ($blockTypes as $blockType)
             {
-                $Block = $this->{'block'.$blockType}($Line, $CurrentBlock);
+                $Block = $this->{"block$blockType"}($Line, $CurrentBlock);
 
                 if (isset($Block))
                 {
@@ -309,7 +309,7 @@ class Parsedown
 
         if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
         {
-            $CurrentBlock = $this->{'block'.$CurrentBlock['type'].'Complete'}($CurrentBlock);
+            $CurrentBlock = $this->{"block{$CurrentBlock['type']}Complete"}($CurrentBlock);
         }
 
         # ~
@@ -326,12 +326,12 @@ class Parsedown
 
     protected function isBlockContinuable($Type)
     {
-        return method_exists($this, 'block'.$Type.'Continue');
+        return method_exists($this, "block${Type}Continue");
     }
 
     protected function isBlockCompletable($Type)
     {
-        return method_exists($this, 'block'.$Type.'Complete');
+        return method_exists($this, "block${Type}Complete");
     }
 
     #
@@ -427,7 +427,7 @@ class Parsedown
             return;
         }
 
-        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
+        $Block['element']['rawHtml'] .= "\n{$Line['body']}";
 
         if (strpos($Line['text'], '-->') !== false)
         {
@@ -451,7 +451,7 @@ class Parsedown
 
             if (isset($matches[2]))
             {
-                $class = 'language-'.$matches[2];
+                $class = "language-{$matches[2]}";
 
                 $Element['attributes'] = array(
                     'class' => $class,
@@ -496,7 +496,7 @@ class Parsedown
             return $Block;
         }
 
-        $Block['element']['element']['text'] .= "\n".$Line['body'];
+        $Block['element']['element']['text'] .= "\n{$Line['body']}";
 
         return $Block;
     }
@@ -840,7 +840,7 @@ class Parsedown
             return;
         }
 
-        $Block['element']['rawHtml'] .= "\n".$Line['body'];
+        $Block['element']['rawHtml'] .= "\n{$Line['body']}";
 
         return $Block;
     }
@@ -960,7 +960,7 @@ class Parsedown
                 $alignment = $alignments[$index];
 
                 $HeaderElement['attributes'] = array(
-                    'style' => 'text-align: '.$alignment.';',
+                    'style' => "text-align: $alignment;",
                 );
             }
 
@@ -1031,7 +1031,7 @@ class Parsedown
                 if (isset($Block['alignments'][$index]))
                 {
                     $Element['attributes'] = array(
-                        'style' => 'text-align: '.$Block['alignments'][$index].';',
+                        'style' => "text-align: {$Block['alignments'][$index]};",
                     );
                 }
 
@@ -1135,7 +1135,7 @@ class Parsedown
                     continue;
                 }
 
-                $Inline = $this->{'inline'.$inlineType}($Excerpt);
+                $Inline = $this->{"inline$inlineType"}($Excerpt);
 
                 if ( ! isset($Inline))
                 {
@@ -1263,7 +1263,7 @@ class Parsedown
 
             if ( ! isset($matches[2]))
             {
-                $url = 'mailto:' . $url;
+                $url = "mailto:$url";
             }
 
             return array(
@@ -1472,7 +1472,7 @@ class Parsedown
         if (preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches))
         {
             return array(
-                'element' => array('rawHtml' => '&'.$matches[1].';'),
+                'element' => array('rawHtml' => "&{$matches[1]};"),
                 'extent' => strlen($matches[0]),
             );
         }
@@ -1674,7 +1674,7 @@ class Parsedown
 
         if ($hasName)
         {
-            $markup .= '<'.$Element['name'];
+            $markup .= "<{$Element['name']}";
 
             if (isset($Element['attributes']))
             {
@@ -1685,7 +1685,7 @@ class Parsedown
                         continue;
                     }
 
-                    $markup .= ' '.$name.'="'.self::escape($value).'"';
+                    $markup .= " $name=\"".self::escape($value).'"';
                 }
             }
         }
@@ -1732,7 +1732,7 @@ class Parsedown
                 }
             }
 
-            $markup .= $hasName ? '</'.$Element['name'].'>' : '';
+            $markup .= $hasName ? "</{$Element['name']}>" : '';
         }
         elseif ($hasName)
         {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -182,11 +182,8 @@ class Parsedown
                 continue;
             }
 
-            for (
-                $beforeTab = strstr($line, "\t", true);
-                $beforeTab !== false;
-                $beforeTab = strstr($line, "\t", true)
-            ) {
+            while (($beforeTab = strstr($line, "\t", true)) !== false)
+            {
                 $shortage = 4 - mb_strlen($beforeTab, 'utf-8') % 4;
 
                 $line = $beforeTab
@@ -207,7 +204,8 @@ class Parsedown
 
             if (isset($CurrentBlock['continuable']))
             {
-                $Block = $this->{"block{$CurrentBlock['type']}Continue"}($Line, $CurrentBlock);
+                $methodName = 'block' . $CurrentBlock['type'] . 'Continue';
+                $Block = $this->$methodName($Line, $CurrentBlock);
 
                 if (isset($Block))
                 {
@@ -219,7 +217,8 @@ class Parsedown
                 {
                     if ($this->isBlockCompletable($CurrentBlock['type']))
                     {
-                        $CurrentBlock = $this->{"block{$CurrentBlock['type']}Complete"}($CurrentBlock);
+                        $methodName = 'block' . $CurrentBlock['type'] . 'Complete';
+                        $CurrentBlock = $this->$methodName($CurrentBlock);
                     }
                 }
             }
@@ -300,7 +299,8 @@ class Parsedown
 
         if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
         {
-            $CurrentBlock = $this->{"block{$CurrentBlock['type']}Complete"}($CurrentBlock);
+            $methodName = 'block' . $CurrentBlock['type'] . 'Complete';
+            $CurrentBlock = $this->$methodName($CurrentBlock);
         }
 
         # ~
@@ -317,12 +317,12 @@ class Parsedown
 
     protected function isBlockContinuable($Type)
     {
-        return method_exists($this, "block${Type}Continue");
+        return method_exists($this, 'block' . $Type . 'Continue');
     }
 
     protected function isBlockCompletable($Type)
     {
-        return method_exists($this, "block${Type}Complete");
+        return method_exists($this, 'block' . $Type . 'Complete');
     }
 
     #
@@ -1138,10 +1138,11 @@ class Parsedown
 
                 # cause the new element to 'inherit' our non nestables
 
-                foreach ($nonNestables as $nonNestable)
-                {
-                    $Inline['element']['nonNestables'][] = $nonNestable;
-                }
+
+                $Inline['element']['nonNestables'] = isset($Inline['element']['nonNestables'])
+                    ? array_merge($Inline['element']['nonNestables'], $nonNestables)
+                    : $nonNestables
+                ;
 
                 # the text that comes before the inline
                 $unmarkedText = substr($text, 0, $Inline['position']);

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1597,9 +1597,9 @@ class Parsedown
             {
                 $Element = $this->handle($Element);
             }
-        }
 
-        unset($Element['handler']);
+            unset($Element['handler']);
+        }
 
         return $Element;
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -829,8 +829,9 @@ class Parsedown
 
     protected function blockReference($Line)
     {
-        if (preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches))
-        {
+        if (strpos($Line['text'], ']') !== false
+            and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
+        ) {
             $id = strtolower($matches[1]);
 
             $Data = array(
@@ -1448,8 +1449,9 @@ class Parsedown
 
     protected function inlineSpecialCharacter($Excerpt)
     {
-        if (preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches))
-        {
+        if ($Excerpt['text'][1] !== ' ' and strpos($Excerpt['text'], ';') !== false
+            and preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches)
+        ) {
             return array(
                 'element' => array('rawHtml' => "&{$matches[1]};"),
                 'extent' => strlen($matches[0]),
@@ -1489,8 +1491,9 @@ class Parsedown
             return;
         }
 
-        if (preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE))
-        {
+        if (strpos($Excerpt['context'], 'http') !== false
+            and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
+        ) {
             $url = $matches[0][0];
 
             $Inline = array(

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -409,7 +409,7 @@ class Parsedown
             return;
         }
 
-        $Block['element']['rawHtml'] .= "\n{$Line['body']}";
+        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
 
         if (strpos($Line['text'], '-->') !== false)
         {
@@ -486,7 +486,7 @@ class Parsedown
             return $Block;
         }
 
-        $Block['element']['element']['text'] .= "\n{$Line['body']}";
+        $Block['element']['element']['text'] .= "\n" . $Line['body'];
 
         return $Block;
     }
@@ -819,7 +819,7 @@ class Parsedown
             return;
         }
 
-        $Block['element']['rawHtml'] .= "\n{$Line['body']}";
+        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
 
         return $Block;
     }
@@ -1011,7 +1011,7 @@ class Parsedown
                 if (isset($Block['alignments'][$index]))
                 {
                     $Element['attributes'] = array(
-                        'style' => "text-align: {$Block['alignments'][$index]};",
+                        'style' => 'text-align: ' . $Block['alignments'][$index] . ';',
                     );
                 }
 
@@ -1453,7 +1453,7 @@ class Parsedown
             and preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches)
         ) {
             return array(
-                'element' => array('rawHtml' => "&{$matches[1]};"),
+                'element' => array('rawHtml' => '&' . $matches[1] . ';'),
                 'extent' => strlen($matches[0]),
             );
         }
@@ -1656,7 +1656,7 @@ class Parsedown
 
         if ($hasName)
         {
-            $markup .= "<{$Element['name']}";
+            $markup .= '<' . $Element['name'];
 
             if (isset($Element['attributes']))
             {
@@ -1714,7 +1714,7 @@ class Parsedown
                 }
             }
 
-            $markup .= $hasName ? "</{$Element['name']}>" : '';
+            $markup .= $hasName ? '</' . $Element['name'] . '>' : '';
         }
         elseif ($hasName)
         {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1102,7 +1102,7 @@ class Parsedown
         {
             $marker = $excerpt[0];
 
-            $markerPosition = strpos($text, $marker);
+            $markerPosition = strlen($text) - strlen($excerpt);
 
             $Excerpt = array('text' => $excerpt, 'context' => $text);
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -749,7 +749,9 @@ class Parsedown
 
     protected function blockRule($Line)
     {
-        if (preg_match('/^(['.$Line['text'][0].'])([ ]*+\1){2,}+[ ]*+$/', $Line['text']))
+        $marker = $Line['text'][0];
+
+        if (substr_count($Line['text'], $marker) >= 3 and chop($Line['text'], " $marker") === '')
         {
             $Block = array(
                 'element' => array(

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -383,15 +383,6 @@ class Parsedown
         }
     }
 
-    protected function blockCodeComplete($Block)
-    {
-        $text = $Block['element']['element']['text'];
-
-        $Block['element']['element']['text'] = $text;
-
-        return $Block;
-    }
-
     #
     # Comment
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1218,12 +1218,12 @@ class Parsedown
 
         if ($this->breaksEnabled)
         {
-            $Inline['element']['rawHtml'] = preg_replace('/[ ]*\n/', "<br />\n", $safeText);
+            $Inline['element']['rawHtml'] = preg_replace('/[ ]*+\n/', "<br />\n", $safeText);
             $Inline['element']['allowRawHtmlInSafeMode'] = true;
         }
         else
         {
-            $Inline['element']['rawHtml'] = preg_replace('/(?:[ ][ ]+|[ ]*\\\\)\n/', "<br />\n", $safeText);
+            $Inline['element']['rawHtml'] = preg_replace('/(?:[ ]*+\\\\|[ ]{2,}+)\n/', "<br />\n", $safeText);
             $Inline['element']['allowRawHtmlInSafeMode'] = true;
         }
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -572,13 +572,15 @@ class Parsedown
                 $matches[1] .= ' ';
             }
 
+            $markerWithoutWhitespace = strstr($matches[1], ' ', true);
+
             $Block = array(
                 'indent' => $Line['indent'],
                 'pattern' => $pattern,
                 'data' => array(
                     'type' => $name,
                     'marker' => $matches[1],
-                    'markerType' => ($name === 'ul' ? strstr($matches[1], ' ', true) : substr(strstr($matches[1], ' ', true), -1)),
+                    'markerType' => ($name === 'ul' ? $markerWithoutWhitespace : substr($markerWithoutWhitespace, -1)),
                 ),
                 'element' => array(
                     'name' => $name,

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1196,16 +1196,12 @@ class Parsedown
 
         $safeText = self::escape($text, true);
 
-        if ($this->breaksEnabled)
-        {
-            $Inline['element']['rawHtml'] = preg_replace('/[ ]*+\n/', "<br />\n", $safeText);
-            $Inline['element']['allowRawHtmlInSafeMode'] = true;
-        }
-        else
-        {
-            $Inline['element']['rawHtml'] = preg_replace('/(?:[ ]*+\\\\|[ ]{2,}+)\n/', "<br />\n", $safeText);
-            $Inline['element']['allowRawHtmlInSafeMode'] = true;
-        }
+        $Inline['element']['rawHtml'] = preg_replace(
+            $this->breaksEnabled ? '/[ ]*+\n/' : '/(?:[ ]*+\\\\|[ ]{2,}+)\n/',
+            "<br />\n",
+            $safeText
+        );
+        $Inline['element']['allowRawHtmlInSafeMode'] = true;
 
         return $Inline;
     }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -773,10 +773,8 @@ class Parsedown
             return;
         }
 
-        if (
-            chop(chop($Line['text'], ' '), $Line['text'][0]) === ''
-            and $Line['indent'] < 4
-        ) {
+        if ($Line['indent'] < 4 and chop(chop($Line['text'], ' '), $Line['text'][0]) === '')
+        {
             $Block['element']['name'] = $Line['text'][0] === '=' ? 'h1' : 'h2';
 
             return $Block;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -199,12 +199,7 @@ class Parsedown
                 }
             }
 
-            $indent = 0;
-
-            while (isset($line[$indent]) and $line[$indent] === ' ')
-            {
-                $indent ++;
-            }
+            $indent = strspn($line, ' ');
 
             $text = $indent > 0 ? substr($line, $indent) : $line;
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -497,12 +497,7 @@ class Parsedown
 
     protected function blockHeader($Line)
     {
-        $level = 1;
-
-        while (isset($Line['text'][$level]) and $Line['text'][$level] === '#')
-        {
-            $level ++;
-        }
+        $level = strspn($Line['text'], '#');
 
         if ($level > 6)
         {

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -182,21 +182,17 @@ class Parsedown
                 continue;
             }
 
-            if (strpos($line, "\t") !== false)
-            {
-                $parts = explode("\t", $line);
+            for (
+                $beforeTab = strstr($line, "\t", true);
+                $beforeTab !== false;
+                $beforeTab = strstr($line, "\t", true)
+            ) {
+                $shortage = 4 - mb_strlen($beforeTab, 'utf-8') % 4;
 
-                $line = $parts[0];
-
-                unset($parts[0]);
-
-                foreach ($parts as $part)
-                {
-                    $shortage = 4 - mb_strlen($line, 'utf-8') % 4;
-
-                    $line .= str_repeat(' ', $shortage);
-                    $line .= $part;
-                }
+                $line = $beforeTab
+                    . str_repeat(' ', $shortage)
+                    . substr($line, strlen($beforeTab) + 1)
+                ;
             }
 
             $indent = strspn($line, ' ');

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1211,32 +1211,20 @@ class Parsedown
     {
         $Inline = array(
             'extent' => strlen($text),
-            'element' => array(
-                'elements' => array(),
-            ),
+            'element' => array(),
         );
+
+        $safeText = self::escape($text, true);
 
         if ($this->breaksEnabled)
         {
-            $Inline['element']['elements'] = self::pregReplaceElements(
-                '/[ ]*\n/',
-                array(
-                    array('name' => 'br'),
-                    array('text' => "\n"),
-                ),
-                $text
-            );
+            $Inline['element']['rawHtml'] = preg_replace('/[ ]*\n/', "<br />\n", $safeText);
+            $Inline['element']['allowRawHtmlInSafeMode'] = true;
         }
         else
         {
-            $Inline['element']['elements'] = self::pregReplaceElements(
-                '/(?:[ ][ ]+|[ ]*\\\\)\n/',
-                array(
-                    array('name' => 'br'),
-                    array('text' => "\n"),
-                ),
-                $text
-            );
+            $Inline['element']['rawHtml'] = preg_replace('/(?:[ ][ ]+|[ ]*\\\\)\n/', "<br />\n", $safeText);
+            $Inline['element']['allowRawHtmlInSafeMode'] = true;
         }
 
         return $Inline;

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1114,6 +1114,8 @@ class Parsedown
     {
         $Elements = array();
 
+        $nonNestables = array_combine($nonNestables, $nonNestables);
+
         # $excerpt is based on the first occurrence of a marker
 
         while ($excerpt = strpbrk($text, $this->inlineMarkerList))
@@ -1128,7 +1130,7 @@ class Parsedown
             {
                 # check to see if the current inline type is nestable in the current context
 
-                if ( ! empty($nonNestables) and in_array($inlineType, $nonNestables))
+                if (isset($nonNestables[$inlineType]))
                 {
                     continue;
                 }

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1094,7 +1094,10 @@ class Parsedown
     {
         $Elements = array();
 
-        $nonNestables = array_combine($nonNestables, $nonNestables);
+        $nonNestables = (empty($nonNestables)
+            ? array()
+            : array_combine($nonNestables, $nonNestables)
+        );
 
         # $excerpt is based on the first occurrence of a marker
 

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1190,14 +1190,11 @@ class Parsedown
         $InlineText = $this->inlineText($text);
         $Elements[] = $InlineText['element'];
 
-        $Elements = array_map(
-            function ($Element) {
-                $Element['autobreak'] = isset($Element['autobreak'])
-                    ? $Element['autobreak'] : false;
-                return $Element;
-            },
-            $Elements
-        );
+        foreach ($Elements as &$Element)
+        {
+            $Element['autobreak'] = isset($Element['autobreak'])
+                ? $Element['autobreak'] : false;
+        }
 
         return $Elements;
     }


### PR DESCRIPTION
This might be the first PR in a while that *reduces* the size of the codebase very slightly ;p

As measured by a few markbench runs, this PR makes Parsedown about 15-20% faster on the github sample profile, and about 10% faster when run without a profile specified. These being run on PHP 7.2.4, and performance diffs are in comparison to 1.8.0-beta-1.

Its probably worth cherry-picking some of these commits over some others. Adjustments to the `inlineText` function have major performance improvements, v.s. things like swapping regular expressions for loops – which doesn't appear to offer much of an observable benefit on my system (latest PHP version at present).

Adjustments towards regular expressions may be beneficial where Parsedown would previously encounter catastrophic backtracking with certain inputs.

Adjustments to string concatenation syntax appear to offer no observable difference in Parsedown in my testing (despite historic benchmarks from the PHP community apparently indicating a difference).