### PR TITLE
Compatability fixes

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1585,6 +1585,7 @@ class Parsedown
             {
                 $function = $Element['handler'];
                 $argument = $Element['text'];
+                unset($Element['text']);
                 $destination = 'rawHtml';
             }
             else

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -264,7 +264,7 @@ class Parsedown
                     {
                         if (isset($CurrentBlock))
                         {
-                            $Elements[] = $CurrentBlock['element'];
+                            $Elements[] = $this->extractElement($CurrentBlock);
                         }
 
                         $Block['identified'] = true;
@@ -296,7 +296,7 @@ class Parsedown
             {
                 if (isset($CurrentBlock))
                 {
-                    $Elements[] = $CurrentBlock['element'];
+                    $Elements[] = $this->extractElement($CurrentBlock);
                 }
 
                 $CurrentBlock = $this->paragraph($Line);
@@ -316,12 +316,22 @@ class Parsedown
 
         if (isset($CurrentBlock))
         {
-            $Elements[] = $CurrentBlock['element'];
+            $Elements[] = $this->extractElement($CurrentBlock);
         }
 
         # ~
 
         return $Elements;
+    }
+
+    protected function extractElement(array $Component)
+    {
+        if ( ! isset($Component['element']) and isset($Component['markup']))
+        {
+            $Component['element'] = array('rawHtml' => $Component['markup']);
+        }
+
+        return $Component['element'];
     }
 
     protected function isBlockContinuable($Type)
@@ -1169,7 +1179,7 @@ class Parsedown
                 $Elements[] = $InlineText['element'];
 
                 # compile the inline
-                $Elements[] = $Inline['element'];
+                $Elements[] = $this->extractElement($Inline);
 
                 # remove the examined text
                 $text = substr($text, $Inline['position'] + $Inline['extent']);


### PR DESCRIPTION
We should unset the text key if inferring it as a handler argument (since otherwise it'll be preferred over `rawHtml`, and might not even be a supported type – e.g. and array).

Adds compatibility for extensions that may have used the old unsafe `markup` block/inline key. We reroute this to the AST compatible `rawHtml` key, but do not mark it as safe (thus if safe mode is enabled it'll be escaped). If extensions know that this is safe, they can update their code to mark it as safe.

