### PR TITLE
Drop eol and near eol versions of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,15 @@
 language: php
 
-dist: trusty
 sudo: false
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: nightly
-    - php: hhvm
-    - php: hhvm-nightly
   fast_finish: true
   allow_failures:
     - php: nightly
-    - php: hhvm-nightly
 
 install:
   - composer install --prefer-dist --no-interaction --no-progress

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Better Markdown Parser in PHP
 * Super Fast
 * Extensible
 * [GitHub flavored](https://help.github.com/articles/github-flavored-markdown)
-* Tested in 5.3 to 7.2 and in HHVM
+* Tested in 7.1 to 7.2
 * [Markdown Extra extension](https://github.com/erusev/parsedown-extra)
 
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.1",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Per http://php.net/supported-versions.php PHP 7.0 is in security fix only mode and will cease to be supported in 7 months.

This PR is a proposal to start 2.0 from the latest actively supported PHP release, 7.1.

---

If merged, closes #619 