### PR TITLE
Drop EOL PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: php
 
-dist: trusty
 sudo: false
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Better Markdown Parser in PHP
 * Super Fast
 * Extensible
 * [GitHub flavored](https://help.github.com/articles/github-flavored-markdown)
-* Tested in 5.3 to 7.2 and in HHVM
+* Tested in 5.6 to 7.2 and in HHVM
 * [Markdown Extra extension](https://github.com/erusev/parsedown-extra)
 
 ### Installation

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.0|^5.6",
         "ext-mbstring": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Similar to #618, but keeps support for PHP 5.6, 7.0 and HHVM.

---

If merged closes #618 