### PR TITLE
Tilde characters may be escaped

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1955,7 +1955,7 @@ class Parsedown
     # Read-Only
 
     protected $specialCharacters = array(
-        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|',
+        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|', '~'
     );
 
     protected $StrongRegex = array(

--- a/test/data/strikethrough.html
+++ b/test/data/strikethrough.html
@@ -1,3 +1,4 @@
 <p><del>strikethrough</del></p>
 <p>here's <del>one</del> followed by <del>another one</del></p>
 <p>~~ this ~~ is not one neither is ~this~</p>
+<p>escaped ~~this~~</p>

--- a/test/data/strikethrough.md
+++ b/test/data/strikethrough.md
@@ -3,3 +3,5 @@
 here's ~~one~~ followed by ~~another one~~
 
 ~~ this ~~ is not one neither is ~this~
+
+escaped \~\~this\~\~


### PR DESCRIPTION
According to http://spec.commonmark.org/0.28/#example-289 and https://github.github.com/gfm/#example-299 one should be able to escape a list of punctuation characters. Tilde is one of them