### PR TITLE
Intepret special "hidden" key as an empty element

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -317,9 +317,16 @@ class Parsedown
 
     protected function extractElement(array $Component)
     {
-        if ( ! isset($Component['element']) and isset($Component['markup']))
+        if ( ! isset($Component['element']))
         {
-            $Component['element'] = array('rawHtml' => $Component['markup']);
+            if (isset($Component['markup']))
+            {
+                $Component['element'] = array('rawHtml' => $Component['markup']);
+            }
+            elseif (isset($Component['hidden']))
+            {
+                $Component['element'] = array();
+            }
         }
 
         return $Component['element'];


### PR DESCRIPTION
Fixes erusev/parsedown-extra#123

The hidden key used to be used to avoid rendering an element – in AST language this is just an element with no name or contents (i.e. empty)