### PR TITLE
Preserve plain-text in AST to avoid blinding extensions to it

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1215,14 +1215,14 @@ class Parsedown
             'element' => array(),
         );
 
-        $safeText = self::escape($text, true);
-
-        $Inline['element']['rawHtml'] = preg_replace(
+        $Inline['element']['elements'] = self::pregReplaceElements(
             $this->breaksEnabled ? '/[ ]*+\n/' : '/(?:[ ]*+\\\\|[ ]{2,}+)\n/',
-            "<br />\n",
-            $safeText
+            array(
+                array('name' => 'br'),
+                array('text' => "\n"),
+            ),
+            $text
         );
-        $Inline['element']['allowRawHtmlInSafeMode'] = true;
 
         return $Inline;
     }


### PR DESCRIPTION
Revert the `preg_replace` straight to rawHtml introduced in #614 so that extensions can have access to the AST if they overload `inlineText`. e.g. ParsedownExtra will use the AST to insert abbreviations: https://travis-ci.org/erusev/parsedown-extra/jobs/376557504#L196-L201

A `preg_replace` on something that is already HTML risks catching text inside attributes/tag names, so AST access is necessary for modifying the text reliably.