### PR TITLE
Restore existence of protected API methods

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -391,6 +391,11 @@ class Parsedown
         }
     }
 
+    protected function blockCodeComplete($Block)
+    {
+        return $Block;
+    }
+
     #
     # Comment
 
@@ -505,6 +510,11 @@ class Parsedown
 
         $Block['element']['element']['text'] .= "\n" . $Line['body'];
 
+        return $Block;
+    }
+
+    protected function blockFencedCodeComplete($Block)
+    {
         return $Block;
     }
 


### PR DESCRIPTION
Fixes #640.

While these functions aren't needed (any more) there isn't really a need to remove a previously existing  part of the interface that could cause breakage for extensions calling these functions directly.