### PR TITLE
Feature request: headerOffset

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -101,6 +101,15 @@ class Parsedown
 
     protected $strictMode;
 
+    function setHeaderOffset($headerOffset)
+    {
+        $this->headerOffset = $headerOffset;
+
+        return $this;
+    }
+
+    protected $headerOffset = 0;
+
     protected $safeLinksWhitelist = array(
         'http://',
         'https://',
@@ -542,7 +551,7 @@ class Parsedown
 
         $Block = array(
             'element' => array(
-                'name' => 'h' . $level,
+                'name' => 'h' . min(6, $level + $this->headerOffset),
                 'handler' => array(
                     'function' => 'lineElements',
                     'argument' => $text,

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -196,4 +196,16 @@ EXPECTED_HTML;
         $sameInstanceAgain = TestParsedown::instance('test late static binding');
         $this->assertSame($testParsedown, $sameInstanceAgain);
     }
+
+    function testHeaderOffset()
+    {
+        $markdown = '## header 2';
+        $expectedMarkup = '<h4>header 2</h4>';
+
+        $this->Parsedown->setHeaderOffset(2);
+
+        $actualMarkup = $this->Parsedown->text($markdown);
+
+        $this->assertEquals($expectedMarkup, $actualMarkup);
+    }
 }


### PR DESCRIPTION
Markdown is often used to render user generated content as part of a website. In this context, it is important to fit it into the document outline, especially for accessibility. pandoc has the `--base-header-level=NUMBER` option for that. I suggest adding similar functionality to parsedown.