### PR TITLE
Enable markdown inside details and summary tags

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1963,8 +1963,8 @@ class Parsedown
     );
 
     protected $textLevelElements = array(
-        'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont',
-        'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',
+        'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont', 'details',
+        'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',             'summary',
         'i', 'rp', 'del', 'code',          'strike', 'marquee',
         'q', 'rt', 'ins', 'font',          'strong',
         's', 'tt', 'kbd', 'mark',


### PR DESCRIPTION
There was not able to render markdown inside `<details>` tags right now. My feature enables markdown rendering inside it.

**BEFORE**
![details1](https://user-images.githubusercontent.com/13667212/44397116-615fef80-a53f-11e8-9c47-f586481bd869.png)

<details>
<summary>CLICK ME</summary>
... formatting like _italics_, **bold**, etc. all fail, just because there's a missing line. > Blockquote without a precending blank line is assumed to belong to the previous line ``` and the same with code blocks. ```
</details>

***

**AFTER**
![details2](https://user-images.githubusercontent.com/13667212/44397122-69b82a80-a53f-11e8-990e-f863acfdb267.png)

<details><summary>CLICK ME</summary>

... formatting like _italics_, **bold**, etc. all fail, just because there's a missing line.

> Blockquote without a precending blank line is assumed to belong to the previous line 

``` and the same with code blocks. ```
</details>
