### PR TITLE
remove redundant header level cap

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -541,7 +541,7 @@ class Parsedown
 
         $Block = array(
             'element' => array(
-                'name' => 'h' . min(6, $level),
+                'name' => 'h' . $level,
                 'handler' => array(
                     'function' => 'lineElements',
                     'argument' => $text,


### PR DESCRIPTION
As we already determine the heading level with strspn and return if it is greater than 6 there is no reason to use the min function here.