### PR TITLE
Add "tel:" to whitelist

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -107,6 +107,7 @@ class Parsedown
         'ftp://',
         'ftps://',
         'mailto:',
+        'tel:',
         'data:image/png;base64,',
         'data:image/gif;base64,',
         'data:image/jpeg;base64,',


### PR DESCRIPTION
Unless there is a way to customize the "safe links" whitelist, we should allow `tel:` links.