### PR TITLE
Ensure line-breaks get standardised when using Parsedown via `line` method

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1119,6 +1119,9 @@ class Parsedown
 
     protected function lineElements($text, $nonNestables = array())
     {
+        # standardize line breaks
+        $text = str_replace(array("\r\n", "\r"), "\n", $text);
+
         $Elements = array();
 
         $nonNestables = (empty($nonNestables)


### PR DESCRIPTION
As noted in https://github.com/erusev/parsedown/pull/624 there are occasions where line break standardisation is assumed (e.g. where `inlineCode` replaces line breaks with a space).

Closes #624