### PR TITLE
Added setLinksOpenNewTab

### DIFF
--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -84,6 +84,14 @@ class Parsedown
     }
 
     protected $urlsLinked = true;
+    
+    function setLinksOpenNewTab($linksOpenNewTab) {
+        $this->linksOpenNewTab = $linksOpenNewTab;
+        
+        return $this;
+    }
+    
+    protected $linksOpenNewTab = false;
 
     function setSafeMode($safeMode)
     {
@@ -1440,6 +1448,11 @@ class Parsedown
 
             $Element['attributes']['href'] = $Definition['url'];
             $Element['attributes']['title'] = $Definition['title'];
+        }
+        
+        if ($this->linksOpenNewTab)
+        {
+            $Element['attributes']['target'] = '_blank';
         }
 
         return array(


### PR DESCRIPTION
A simple variable that, when `true`, sets `target` attribute to `_blank` when generating an `a` tag for markdown links. Great utility for anyone who wants to enforce all links to open in a new tab without having to create an extension.