### PR TITLE
Added a hook to change blocks on-the-fly

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -13,11 +13,14 @@
 #
 #
 
-class Parsedown
+class Parsedown 
 {
     # ~
 
     const version = '1.8.0-beta-7';
+
+    # ~ 
+    protected $texthook = NULL;
 
     # ~
 
@@ -1720,6 +1723,11 @@ class Parsedown
 
         $permitRawHtml = false;
 
+        // Add a hook for change blocks on the fly
+        if(is_callable($this->texthook)) {
+            $Element = call_user_func($this->texthook, $Element);
+        }
+
         if (isset($Element['text']))
         {
             $text = $Element['text'];
@@ -1750,6 +1758,8 @@ class Parsedown
             }
             else
             {
+                
+
                 if (!$permitRawHtml)
                 {
                     $markup .= self::escape($text, true);
@@ -1768,6 +1778,13 @@ class Parsedown
         }
 
         return $markup;
+    }
+
+    /**
+     * Set callback hool
+     */
+    public function setTextHook($callback) {
+        $this->texthook = $callback;
     }
 
     protected function elements(array $Elements)


### PR DESCRIPTION
I see alot issue about change text and block style, like a Geshi or new styles

I see it's confuse create Extras for every block we need to change. I'm big fan of hooks, so, I implemented something like that to do any change on-the-fly.

Something like that:

```php
$Parsedown = new Parsedown();

// Hook for change element blocks
$Parsedown->setTextHook(function($Element) {

	// Look for code block
	if($Element['name'] === "code") {
		$geshi = new Geshi($Element['text'], str_replace("language-", "", $Element['attributes']['class']), "/media/backup/www/andor.com.br/library/General/Library/Geshi/geshi/");
		$geshi->set_header_type(GESHI_HEADER_NONE);
		unset($Element['text']);

		$Element['rawHtml'] = $geshi->parse_code();
		$Element['allowRawHtmlInSafeMode'] = TRUE;
	}

	// ANOTHER ONE TO CHANGE
	elseif (1) {

	}

	// Return the same element block
	return $Element;
});
```


I don't know if you like or it's can be useful for you. But, was already coded!