### PR TITLE
Opt in raw html

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
     - php: nightly
   fast_finish: true
   allow_failures:

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1489,22 +1489,41 @@ class Parsedown
             }
         }
 
+        $permitRawHtml = false;
+
         if (isset($Element['text']))
+        {
+            $text = $Element['text'];
+        }
+        // very strongly consider an alternative if you're writing an
+        // extension
+        elseif (isset($Element['rawHtml']))
+        {
+            $text = $Element['rawHtml'];
+            $allowRawHtmlInSafeMode = isset($Element['allowRawHtmlInSafeMode']) && $Element['allowRawHtmlInSafeMode'];
+            $permitRawHtml = !$this->safeMode || $allowRawHtmlInSafeMode;
+        }
+
+        if (isset($text))
         {
             $markup .= '>';
 
-            if (!isset($Element['nonNestables'])) 
+            if (!isset($Element['nonNestables']))
             {
                 $Element['nonNestables'] = array();
             }
 
             if (isset($Element['handler']))
             {
-                $markup .= $this->{$Element['handler']}($Element['text'], $Element['nonNestables']);
+                $markup .= $this->{$Element['handler']}($text, $Element['nonNestables']);
+            }
+            elseif (!$permitRawHtml)
+            {
+                $markup .= self::escape($text, true);
             }
             else
             {
-                $markup .= self::escape($Element['text'], true);
+                $markup .= $text;
             }
 
             $markup .= '</'.$Element['name'].'>';

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -17,7 +17,7 @@ class Parsedown
 {
     # ~
 
-    const version = '1.7.3';
+    const version = '1.7.4-dev';
 
     # ~
 

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require 'SampleExtensions.php';
+
 use PHPUnit\Framework\TestCase;
 
 class ParsedownTest extends TestCase
@@ -53,6 +55,40 @@ class ParsedownTest extends TestCase
         $actualMarkup = $this->Parsedown->text($markdown);
 
         $this->assertEquals($expectedMarkup, $actualMarkup);
+    }
+
+    function testRawHtml()
+    {
+        $markdown = "```php\nfoobar\n```";
+        $expectedMarkup = '<pre><code class="language-php"><p>foobar</p></code></pre>';
+        $expectedSafeMarkup = '<pre><code class="language-php">&lt;p&gt;foobar&lt;/p&gt;</code></pre>';
+
+        $unsafeExtension = new UnsafeExtension;
+        $actualMarkup = $unsafeExtension->text($markdown);
+
+        $this->assertEquals($expectedMarkup, $actualMarkup);
+
+        $unsafeExtension->setSafeMode(true);
+        $actualSafeMarkup = $unsafeExtension->text($markdown);
+
+        $this->assertEquals($expectedSafeMarkup, $actualSafeMarkup);
+    }
+
+    function testTrustDelegatedRawHtml()
+    {
+        $markdown = "```php\nfoobar\n```";
+        $expectedMarkup = '<pre><code class="language-php"><p>foobar</p></code></pre>';
+        $expectedSafeMarkup = $expectedMarkup;
+
+        $unsafeExtension = new TrustDelegatedExtension;
+        $actualMarkup = $unsafeExtension->text($markdown);
+
+        $this->assertEquals($expectedMarkup, $actualMarkup);
+
+        $unsafeExtension->setSafeMode(true);
+        $actualSafeMarkup = $unsafeExtension->text($markdown);
+
+        $this->assertEquals($expectedSafeMarkup, $actualSafeMarkup);
     }
 
     function data()

--- a/test/SampleExtensions.php
+++ b/test/SampleExtensions.php
@@ -1,0 +1,39 @@
+<?php
+
+class UnsafeExtension extends Parsedown
+{
+    protected function blockFencedCodeComplete($Block)
+    {
+        $text = $Block['element']['text']['text'];
+        unset($Block['element']['text']['text']);
+
+        // WARNING: There is almost always a better way of doing things!
+        //
+        // This example is one of them, unsafe behaviour is NOT needed here.
+        // Only use this if you trust the input and have no idea what
+        // the output HTML will look like (e.g. using an external parser).
+        $Block['element']['text']['rawHtml'] = "<p>$text</p>";
+
+        return $Block;
+    }
+}
+
+class TrustDelegatedExtension extends Parsedown
+{
+    protected function blockFencedCodeComplete($Block)
+    {
+        $text = $Block['element']['text']['text'];
+        unset($Block['element']['text']['text']);
+
+        // WARNING: There is almost always a better way of doing things!
+        //
+        // This behaviour is NOT needed in the demonstrated case.
+        // Only use this if you are sure that the result being added into
+        // rawHtml is safe.
+        // (e.g. using an external parser with escaping capabilities).
+        $Block['element']['text']['rawHtml'] = "<p>$text</p>";
+        $Block['element']['text']['allowRawHtmlInSafeMode'] = true;
+
+        return $Block;
+    }
+}


### PR DESCRIPTION
Backports https://github.com/erusev/parsedown/pull/569 to 1.7.x

This feature is not used in this port, only permits extensions to utilise rawHtml mechanics. In 1.8 beta versions this feature is utilised internally and *might* have compatibility issues with extensions.