### PR TITLE
Add mutable configurable

### DIFF
--- a/src/Components/Blocks/Reference.php
+++ b/src/Components/Blocks/Reference.php
@@ -43,9 +43,7 @@ final class Reference implements StateUpdatingBlock
                 'title' => isset($matches[3]) ? $matches[3] : null,
             ];
 
-            $State = $State->setting(
-                $State->get(DefinitionBook::class)->setting($id, $Data)
-            );
+            $State->get(DefinitionBook::class)->mutatingSet($id, $Data);
 
             return new self($State);
         }

--- a/src/Configurables/DefinitionBook.php
+++ b/src/Configurables/DefinitionBook.php
@@ -2,12 +2,12 @@
 
 namespace Erusev\Parsedown\Configurables;
 
-use Erusev\Parsedown\Configurable;
+use Erusev\Parsedown\MutableConfigurable;
 
 /**
  * @psalm-type _Data=array{url: string, title: string|null}
  */
-final class DefinitionBook implements Configurable
+final class DefinitionBook implements MutableConfigurable
 {
     /** @var array<string, _Data> */
     private $book;
@@ -29,14 +29,10 @@ final class DefinitionBook implements Configurable
     /**
      * @param string $id
      * @param _Data $data
-     * @return self
      */
-    public function setting($id, array $data)
+    public function mutatingSet($id, array $data): void
     {
-        $book = $this->book;
-        $book[$id] = $data;
-
-        return new self($book);
+        $this->book[$id] = $data;
     }
 
     /**
@@ -50,5 +46,10 @@ final class DefinitionBook implements Configurable
         }
 
         return null;
+    }
+
+    public function isolatedCopy(): self
+    {
+        return new self($this->book);
     }
 }

--- a/src/MutableConfigurable.php
+++ b/src/MutableConfigurable.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Erusev\Parsedown;
+
+/**
+ * Beware that the values of MutableConfigurables are NOT stable. Values SHOULD
+ * be accessed as close to use as possible. Parsing operations sharing the same
+ * State SHOULD NOT be triggered between where values are read and where they
+ * need to be relied upon.
+ */
+interface MutableConfigurable extends Configurable
+{
+    /**
+     * Objects contained in State can generally be regarded as immutable,
+     * however, when mutability is *required* then isolatedCopy (this method)
+     * MUST be implemented to take a reliable copy of the contained state,
+     * which MUST be fully seperable from the current instance. This is
+     * sometimes referred to as a "deep copy".
+     *
+     * The following assumption is made when you implement
+     * MutableConfigurable:
+     *
+     *   A shared, (more or less) globally writable, instantaniously updating
+     *   (at all parsing levels), single copy of a Configurable is intentional
+     *   and desired.
+     *
+     * As such, Parsedown will use the isolatedCopy method to ensure state
+     * isolation between successive parsing calls (which are considered to be
+     * isolated documents).
+     *
+     * You MUST NOT depend on the method `initial` being called when a clean
+     * parsing state is desired, this will not reliably occur; implement
+     * isolatedCopy properly to allow Parsedown to manage this.
+     *
+     * Failing to implement this method properly can result in unintended
+     * side-effects. If possible, you should design your Configurable to be
+     * immutable, which allows a single copy to be shared safely, and mutations
+     * localised to a heirarchy for which the order of operations is easy to
+     * reason about.
+     *
+     * @return static
+     */
+    public function isolatedCopy();
+}

--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -31,7 +31,7 @@ final class Parsedown
     {
         $StateBearer = $StateBearer ?: new State;
 
-        $this->State = $StateBearer->state();
+        $this->State = $StateBearer->state()->isolatedCopy();
     }
 
     /**
@@ -42,7 +42,7 @@ final class Parsedown
     {
         list($StateRenderables, $State) = self::lines(
             Lines::fromTextLines($markdown, 0),
-            $this->State
+            $this->State->isolatedCopy()
         );
 
         $Renderables = $State->applyTo($StateRenderables);


### PR DESCRIPTION
`Configurable`s are designed to be immutable because it makes working with them and reasoning about their values much easier (see: https://github.com/erusev/parsedown/pull/708#issuecomment-576026421), however in some very special cases mutability might be required to create special behaviours (envisioned use case for this is mostly where definitions are recorded and need to be accessible by the whole parsing tree).

To quote the embedded description for the `MutableConfigurable` interface:

> Beware that the values of MutableConfigurables are NOT stable. Values SHOULD
be accessed as close to use as possible. Parsing operations sharing the same
State SHOULD NOT be triggered between where values are read and where they
need to be relied upon.