### PR TITLE
Add tel: linktype to whitelist

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -117,6 +117,7 @@ class Parsedown
         'ssh:',
         'news:',
         'steam:',
+        'tel:'
     );
 
     #


### PR DESCRIPTION
Please consider adding this link type to the whitelist.
It's commonly recognized among modern browsers and especially convenient on mobile devices.