### PR TITLE
Add option to open links in new tab (1.7.x Version)

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -101,6 +101,15 @@ class Parsedown
         'steam:',
     );
 
+    protected $useTargetBlankLinks = false;
+
+    function setTargetBlankLinks($useTargetBlankLinks)
+    {
+        $this->useTargetBlankLinks = (bool)$useTargetBlankLinks;
+
+        return $this;
+    }
+
     #
     # Lines
     #
@@ -1154,6 +1163,16 @@ class Parsedown
         }
     }
 
+    protected function updateLinkAttributes($attributes)
+    {
+      if ($this->useTargetBlankLinks)
+      {
+          $attributes['target'] = '_blank';
+          $attributes['rel'] = 'noopener noreferrer';
+      }
+      return $attributes;
+    }
+
     protected function inlineEmailTag($Excerpt)
     {
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<((mailto:)?\S+?@\S+?)>/i', $Excerpt['text'], $matches))
@@ -1170,9 +1189,9 @@ class Parsedown
                 'element' => array(
                     'name' => 'a',
                     'text' => $matches[1],
-                    'attributes' => array(
+                    'attributes' => $this->updateLinkAttributes(array(
                         'href' => $url,
-                    ),
+                    )),
                 ),
             );
         }
@@ -1262,10 +1281,10 @@ class Parsedown
             'handler' => 'line',
             'nonNestables' => array('Url', 'Link'),
             'text' => null,
-            'attributes' => array(
+            'attributes' => $this->updateLinkAttributes(array(
                 'href' => null,
                 'title' => null,
-            ),
+            )),
         );
 
         $extent = 0;
@@ -1417,9 +1436,9 @@ class Parsedown
                 'element' => array(
                     'name' => 'a',
                     'text' => $url,
-                    'attributes' => array(
+                    'attributes' => $this->updateLinkAttributes(array(
                         'href' => $url,
-                    ),
+                    )),
                 ),
             );
 
@@ -1438,9 +1457,9 @@ class Parsedown
                 'element' => array(
                     'name' => 'a',
                     'text' => $url,
-                    'attributes' => array(
+                    'attributes' => $this->updateLinkAttributes(array(
                         'href' => $url,
-                    ),
+                    )),
                 ),
             );
         }


### PR DESCRIPTION
- This allows you to specify that links should be opened in a new tab by setting `setTargetBlankLinks`.
- Same concept as #777, but that can be merged into the 1.7.x releases.