### PR TITLE
Fix html entities double encoding in html attributes

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1918,7 +1918,7 @@ class Parsedown
 
     protected static function escape($text, $allowQuotes = false)
     {
-        return htmlspecialchars($text, $allowQuotes ? ENT_NOQUOTES : ENT_QUOTES, 'UTF-8');
+        return htmlspecialchars($text, $allowQuotes ? ENT_NOQUOTES : ENT_QUOTES, 'UTF-8', false);
     }
 
     protected static function striAtStart($string, $needle)

--- a/test/data/image_reference.html
+++ b/test/data/image_reference.html
@@ -1,2 +1,3 @@
 <p><img src="/md.png" alt="Markdown Logo" /></p>
 <p>![missing reference]</p>
+<p><img src="/md.png" alt="Markdown Logo with html entity as used in french&nbsp;!" /></p>

--- a/test/data/image_reference.md
+++ b/test/data/image_reference.md
@@ -3,3 +3,5 @@
 [image]: /md.png
 
 ![missing reference]
+
+![Markdown Logo with html entity as used in french&nbsp;!][image]


### PR DESCRIPTION
This patch fix the fact that unbreakable space entity `&nbsp;` is double encoded `&amp;&nbsp;` in image `alt` attributes, which is not nice

Provided test and fix