### PR TITLE
Make autoloading more standard using classmaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,4 @@ install:
 
 script:
   - vendor/bin/phpunit
-  - vendor/bin/phpunit test/CommonMarkTestWeak.php || true
   - '[ -z "$TRAVIS_TAG" ] || [ "$TRAVIS_TAG" == "$(php -r "require(\"Parsedown.php\"); echo Parsedown::version;")" ]'

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,9 @@
         "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
-        "psr-0": {"Parsedown": ""}
+        "classmap": ["Parsedown.php"]
     },
     "autoload-dev": {
-        "psr-0": {
-            "TestParsedown": "test/",
-            "ParsedownTest": "test/",
-            "CommonMarkTest": "test/",
-            "CommonMarkTestWeak": "test/"
-        }
+        "classmap": ["test/"]
     }
 }

--- a/test/CommonMarkTestWeak.php
+++ b/test/CommonMarkTestWeak.php
@@ -1,5 +1,4 @@
 <?php
-require_once(__DIR__ . '/CommonMarkTestStrict.php');
 
 /**
  * Test Parsedown against the CommonMark spec, but less aggressive

--- a/test/ParsedownTest.php
+++ b/test/ParsedownTest.php
@@ -1,5 +1,4 @@
 <?php
-require 'SampleExtensions.php';
 
 use PHPUnit\Framework\TestCase;
 

--- a/test/TrustDelegatedExtension.php
+++ b/test/TrustDelegatedExtension.php
@@ -1,24 +1,5 @@
 <?php
 
-class UnsafeExtension extends Parsedown
-{
-    protected function blockFencedCodeComplete($Block)
-    {
-        $text = $Block['element']['element']['text'];
-        unset($Block['element']['element']['text']);
-
-        // WARNING: There is almost always a better way of doing things!
-        //
-        // This example is one of them, unsafe behaviour is NOT needed here.
-        // Only use this if you trust the input and have no idea what
-        // the output HTML will look like (e.g. using an external parser).
-        $Block['element']['element']['rawHtml'] = "<p>$text</p>";
-
-        return $Block;
-    }
-}
-
-
 class TrustDelegatedExtension extends Parsedown
 {
     protected function blockFencedCodeComplete($Block)

--- a/test/UnsafeExtension.php
+++ b/test/UnsafeExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+class UnsafeExtension extends Parsedown
+{
+    protected function blockFencedCodeComplete($Block)
+    {
+        $text = $Block['element']['element']['text'];
+        unset($Block['element']['element']['text']);
+
+        // WARNING: There is almost always a better way of doing things!
+        //
+        // This example is one of them, unsafe behaviour is NOT needed here.
+        // Only use this if you trust the input and have no idea what
+        // the output HTML will look like (e.g. using an external parser).
+        $Block['element']['element']['rawHtml'] = "<p>$text</p>";
+
+        return $Block;
+    }
+}


### PR DESCRIPTION
Since Composer 2.0, files that are supposed to be loaded with PSR-0 or PSR-4 yet are not compliant with PSR-0 or PSR-4 respectively, cannot be autoloaded.

This MR fixes that by using classmaps. Any library requiring Parsedown will not need to be refactored to be able to continue using Parsedown because the classes in this project have not changed names or moved namespaces (except test files).