### PR TITLE
Add comma to specialCharacters list

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1961,7 +1961,7 @@ class Parsedown
     # Read-Only
 
     protected $specialCharacters = array(
-        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|', '~'
+        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|', '~', ','
     );
 
     protected $StrongRegex = array(


### PR DESCRIPTION
This solves wrong behaviour with escaped commas.

You can see this wrong behaiviour using "1\. Hello\, world!" phrase at https://parsedown.org/demo

<img width="893" alt="Screenshot 2021-11-21 at 07 30 55" src="https://user-images.githubusercontent.com/9027592/142752266-f70d7ed9-3d40-420e-9699-2f15fbbdf9c4.png">

This is important because this kind of escape ("1\. Hello\, world!") produced by one of most famous markdown editors - TUI editor.

![2021-11-21 07 34 23](https://user-images.githubusercontent.com/9027592/142752359-d4e0a4f2-08dd-4482-bcf0-857de9b5d08f.gif)

If you write list without marking its as a real list, you will get this kind of escaping and then if you use result in Parsedown, you see "\," instead of just commas.