### PR TITLE
fix issue #746

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1033,7 +1033,7 @@ class Parsedown
             $row = trim($row);
             $row = trim($row, '|');
 
-            preg_match_all('/(?:(\\\\[|])|[^|`]|`[^`]++`|`)++/', $row, $matches);
+            preg_match_all('/(?:(\\\\[|])|`{3,3}.*?`{3,3}|[^|`]|`[^`]++`|`)++/', $row, $matches);
 
             $cells = array_slice($matches[0], 0, count($Block['alignments']));
 


### PR DESCRIPTION
The problem described in the the issue could be simplified to parsing error in case of the following table
```
| header1 | header2 |
| --- | --- |
| ```a``` | ```b``` |
```
Instead of parsing values A and B into separate columns, these values are being concatinated into first column. PR adds one alternative into column value regex, which provides correct parsing of triple backtics