### PR TITLE
Add Option minHeaderLevel

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -83,6 +83,15 @@ class Parsedown
 
     protected $urlsLinked = true;
 
+    function minHeaderLevel($minHeaderLevel)
+    {
+        $this->minHeaderLevel = (int) $minHeaderLevel;
+
+        return $this;
+    }
+
+    protected $minHeaderLevel;
+
     function setSafeMode($safeMode)
     {
         $this->safeMode = (bool) $safeMode;
@@ -539,6 +548,8 @@ class Parsedown
     protected function blockHeader($Line)
     {
         $level = strspn($Line['text'], '#');
+
+        $level = (isset($this->minHeaderLevel) ? $this->minHeaderLevel + $level - 1 : $level);
 
         if ($level > 6)
         {


### PR DESCRIPTION
Add a new option to define the minimal Header level to be used
e.g. if the option `->minHeaderLevel(3)` a header defined with a single hash `# heading` will be parsed as `<h3>heading</h3>`