### PR TITLE
Image lazy loading - tag attribute added

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -1373,6 +1373,7 @@ class Parsedown
                 'attributes' => array(
                     'src' => $Link['element']['attributes']['href'],
                     'alt' => $Link['element']['handler']['argument'],
+                    'loading' => 'lazy',
                 ),
                 'autobreak' => true,
             ),


### PR DESCRIPTION
Lazy image loading is supported by all current browsers per attribute. Devices that do not recognise this attribute actually ignore it.

[https://caniuse.com/?search=loading%3D%22lazy%22](https://caniuse.com/?search=loading%3D%22lazy%22)