### PR TITLE
Add PHP 8.4 support in a PHP >= 5.1 compatible way

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -712,9 +712,9 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, array $Block = array())
     {
-        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        if (empty($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
             return;
         }
@@ -850,9 +850,9 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, array $Block = array())
     {
-        if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
+        if (empty($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
             return;
         }


### PR DESCRIPTION
- This re-does @xabbuh's commit 7b307a92373542a10f1265df420d424ea4d51062 (PR #868)
- Alternative to @MyIgel's PR #899.

I believe mine is the better approach for the 1.7.x branch (which still officially supports PHP 5.3 and later) as it maintains backwards-compatibility for anyone still using PHP < 7.1.

I hope this can be merged quickly, and a new release tagged. Thanks in advance, and let me know if there is anything else I can do to speed that up.
