### PR TITLE
Fix implicit null param deprecation warning in php 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+composer.lock
+.phpunit.*.cache
+

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -712,7 +712,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -850,7 +850,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" colors="true">
 	<testsuites>
-		<testsuite>
+		<testsuite name="Parsedown Test Suite">
 			<file>test/ParsedownTest.php</file>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
This PR introduces a bare minimum updates for `Parsedown` 1.7.4 codebase (`erusev:1.7.x` branch) to avoid 2 major warnings. No other refactoring are made.

### Type Hinting Improvements:
* Updated the method signatures of `blockSetextHeader` and `blockTable` in `Parsedown.php` to allow `null` values for the `$Block` parameter by using nullable type hints (`?array`).
    * This avoids "[deprecation of implicit nullable parameter](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types#code_change_examples)" warnings in PHP 8.4.

### PHPUnit Configuration Update:
* Added a descriptive name, "Parsedown Test Suite," to the `<testsuite>` element in the `phpunit.xml.dist` file.
    * This avoids "[config file validation error](https://docs.phpunit.de/en/9.6/configuration.html#the-testsuite-element)" warnings in PHPUnit 9.6.

### Add `.gitignore`:

* Added a `.gitignore` file to exclude "`vendor/`" dir and cache/lock files to git commit.
