### PR TITLE
1.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,15 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    - php: 8.0
+    - php: 8.1
+    - php: 8.2
+    - php: 8.3
+    - php: 8.4
     - php: nightly
   fast_finish: true
   allow_failures:

--- a/Parsedown.php
+++ b/Parsedown.php
@@ -712,7 +712,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -850,7 +850,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.1.0",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.5|^8.5|^9.6"
+        "phpunit/phpunit": "^7.5|^8.5|^9.6"
     },
     "autoload": {
         "psr-0": {"Parsedown": ""}


### PR DESCRIPTION
### PHP Version Updates:
* `.travis.yml`: Removed support for PHP versions 5.3 through 7.0 new range is from 7.1 through 8.4.
* `composer.json`: Updated the minimum PHP requirement from `>=5.3.0` to `>=7.1.0`.

### Dependency Updates:
* `composer.json`: Adjusted the `phpunit/phpunit` dependency to remove support for versions below `^7.5`.

### Code Modernization:
* `Parsedown.php`: Updated method signatures for `blockSetextHeader` and `blockTable` to use nullable type hints (`?array`) for the `$Block` parameter. fixing the issue `Implicitly marking parameter as nullable is deprecated`


This should be safe to release as a 1.8 or 1.7.1 as the only breaking change is the PHP version and people do not really use that old PHP anymore