### PR TITLE
Dropping legacy PHP

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,17 +1,17 @@
 <?php
+
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+
 $finder = Finder::create()
     ->in(__DIR__ . '/src/')
     ->in(__DIR__ . '/tests/')
 ;
 $rules = [
-    '@PSR2' => true,
+    '@PSR12' => true,
+    '@PHP82Migration' => true,
     'array_syntax' => [
         'syntax' => 'short',
-    ],
-    'braces' => [
-        'allow_single_line_closure' => true,
     ],
     'logical_operators' => true,
     'native_constant_invocation' => [
@@ -20,16 +20,12 @@ $rules = [
     'native_function_invocation' => [
         'include' => ['@all'],
     ],
-    'no_unused_imports' => true,
-    'ordered_imports' => [
-        'sort_algorithm' => 'alpha',
-    ],
-    'single_blank_line_before_namespace' => true,
     'strict_comparison' => true,
     'strict_param' => true,
     'whitespace_after_comma_in_array' => true,
 ];
-return (new Config)
+
+return (new Config())
     ->setRules($rules)
     ->setFinder($finder)
     ->setUsingCache(false)

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "vimeo/psalm": "^6.12",
-        "phpunit/phpunit": "^11.5",
         "friendsofphp/php-cs-fixer": "^3.82",
         "infection/infection": "^0.29",
-        "roave/infection-static-analysis-plugin": "^1.38"
+        "phpunit/phpunit": "^11.5",
+        "roave/infection-static-analysis-plugin": "^1.38",
+        "vimeo/psalm": "^6.12"
     },
     "autoload": {
         "psr-4": {"Erusev\\Parsedown\\": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         }
     ],
     "require": {
-        "php": "^7.1||^8.0",
+        "php": "^8.2",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3.11||^8.5.21||^7.5.20",
-        "vimeo/psalm": "^4.10.0",
-        "friendsofphp/php-cs-fixer": "^3.0.0",
-        "infection/infection": "^0.25.0",
-        "roave/infection-static-analysis-plugin": "^1.10.0"
+        "vimeo/psalm": "^6.12",
+        "phpunit/phpunit": "^11.5",
+        "friendsofphp/php-cs-fixer": "^3.82",
+        "infection/infection": "^0.29",
+        "roave/infection-static-analysis-plugin": "^1.38"
     },
     "autoload": {
         "psr-4": {"Erusev\\Parsedown\\": "src/"}


### PR DESCRIPTION
This pull request updates the project's PHP version compatibility, development dependencies, and coding standards configuration to align with modern practices and PHP 8.2. The most important changes include upgrading to PHP 8.2, updating development dependencies, and adopting newer coding standards.

### PHP Version and Dependency Updates:

* Updated the required PHP version in `composer.json` from `^7.1||^8.0` to `^8.2`, ensuring compatibility with PHP 8.2.
* Updated development dependencies in `composer.json` to newer versions:
  - `phpunit/phpunit` to `^11.5`
  - `vimeo/psalm` to `^6.12`
  - `friendsofphp/php-cs-fixer` to `^3.82`
  - `infection/infection` to `^0.29`
  - `roave/infection-static-analysis-plugin` to `^1.38`

### Coding Standards Configuration:

* Updated `.php-cs-fixer.dist.php` to use the `@PSR12` coding standard instead of `@PSR2` and added the `@PHP82Migration` rule set for modern PHP syntax. Removed several rules to simplify the configuration, such as `no_unused_imports` and `ordered_imports`. as theses are in PSR12 already