### PR TITLE
Update Parsedown.php for issue #923

### DIFF
--- a/Parsedown.php
+++ b/Parsedown.php
@@ -712,7 +712,7 @@ class Parsedown
     #
     # Setext
 
-    protected function blockSetextHeader($Line, array $Block = null)
+    protected function blockSetextHeader($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {
@@ -850,7 +850,7 @@ class Parsedown
     #
     # Table
 
-    protected function blockTable($Line, array $Block = null)
+    protected function blockTable($Line, ?array $Block = null)
     {
         if ( ! isset($Block) or isset($Block['type']) or isset($Block['interrupted']))
         {


### PR DESCRIPTION
edit lines 715 and 853 to address
`Parsedown::blockSetextHeader(): Implicitly marking parameter $Block as nullable is deprecated` message as described in https://github.com/erusev/parsedown/issues/923