### PR TITLE
fix: Change constructor parameter to nullable type

### DIFF
--- a/src/Components/Block.php
+++ b/src/Components/Block.php
@@ -17,6 +17,6 @@ interface Block extends Component
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     );
 }

--- a/src/Components/Blocks/BlockQuote.php
+++ b/src/Components/Blocks/BlockQuote.php
@@ -35,7 +35,7 @@ final class BlockQuote implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if (\preg_match('/^(>[ \t]?+)(.*+)/', $Context->line()->text(), $matches)) {
             $indentOffset = $Context->line()->indentOffset() + $Context->line()->indent() + \strlen($matches[1]);

--- a/src/Components/Blocks/FencedCode.php
+++ b/src/Components/Blocks/FencedCode.php
@@ -51,7 +51,7 @@ final class FencedCode implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         $marker = \substr($Context->line()->text(), 0, 1);
 

--- a/src/Components/Blocks/Header.php
+++ b/src/Components/Blocks/Header.php
@@ -39,7 +39,7 @@ final class Header implements Block
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if ($Context->line()->indent() > 3) {
             return null;

--- a/src/Components/Blocks/IndentedCode.php
+++ b/src/Components/Blocks/IndentedCode.php
@@ -32,7 +32,7 @@ final class IndentedCode implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if (isset($Block) && $Block instanceof Paragraph && ! ($Context->precedingEmptyLines() > 0)) {
             return null;

--- a/src/Components/Blocks/Markup.php
+++ b/src/Components/Blocks/Markup.php
@@ -124,7 +124,7 @@ final class Markup implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         $text = $Context->line()->text();
         $rawLine = $Context->line()->rawLine();

--- a/src/Components/Blocks/Paragraph.php
+++ b/src/Components/Blocks/Paragraph.php
@@ -32,7 +32,7 @@ final class Paragraph implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         return new self($Context->line()->text());
     }

--- a/src/Components/Blocks/Reference.php
+++ b/src/Components/Blocks/Reference.php
@@ -28,7 +28,7 @@ final class Reference implements StateUpdatingBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if (\preg_match(
             '/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/',

--- a/src/Components/Blocks/Rule.php
+++ b/src/Components/Blocks/Rule.php
@@ -22,7 +22,7 @@ final class Rule implements Block
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if ($Context->line()->indent() > 3) {
             return null;

--- a/src/Components/Blocks/SetextHeader.php
+++ b/src/Components/Blocks/SetextHeader.php
@@ -39,7 +39,7 @@ final class SetextHeader implements AcquisitioningBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if (! isset($Block) || ! $Block instanceof Paragraph || $Context->precedingEmptyLines() > 0) {
             return null;

--- a/src/Components/Blocks/TList.php
+++ b/src/Components/Blocks/TList.php
@@ -83,7 +83,7 @@ final class TList implements ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         list($type, $pattern) = (
             \substr($Context->line()->text(), 0, 1) <= '-'

--- a/src/Components/Blocks/Table.php
+++ b/src/Components/Blocks/Table.php
@@ -47,7 +47,7 @@ final class Table implements AcquisitioningBlock, ContinuableBlock
     public static function build(
         Context $Context,
         State $State,
-        Block $Block = null
+        ?Block $Block = null
     ) {
         if (! isset($Block) || ! $Block instanceof Paragraph) {
             return null;

--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -27,7 +27,7 @@ final class Parsedown
     /** @var State */
     private $State;
 
-    public function __construct(StateBearer $StateBearer = null)
+    public function __construct(?StateBearer $StateBearer = null)
     {
         $State = ($StateBearer ?? new State)->state();
 


### PR DESCRIPTION
Fix "Implicitly marking parameter $StateBearer as nullable is deprecated" since php 8.4

```
ErrorException: Deprecated: Erusev\Parsedown\Parsedown::__construct(): Implicitly marking parameter $StateBearer as nullable is deprecated, the explicit nullable type must be used instead
```

Closes #914